### PR TITLE
feat: optimize config for CPU and GPU

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 """Fixtures for the tests."""
 
 import pytest
-from llama_cpp import Llama, LlamaRAMCache  # type: ignore[attr-defined]
+from llama_cpp import Llama
 
 from raglite import RAGLiteConfig
 
@@ -9,15 +9,6 @@ from raglite import RAGLiteConfig
 @pytest.fixture()
 def simple_config() -> RAGLiteConfig:
     """Create a lightweight in-memory config for testing."""
-    # Use a lightweight LLM.
-    llm = Llama.from_pretrained(
-        repo_id="bartowski/Phi-3.1-mini-4k-instruct-GGUF",  # https://huggingface.co/microsoft/Phi-3-mini-4k-instruct
-        filename="*Q4_K_M.gguf",
-        n_ctx=4096,  # 0 = Use the model's context size (default is 512).
-        n_gpu_layers=-1,  # -1 = Offload all layers to the GPU (default is 0).
-        verbose=False,
-    )
-    llm.set_cache(LlamaRAMCache())
     # Use a lightweight embedder.
     embedder = Llama.from_pretrained(
         repo_id="ChristianAzinn/snowflake-arctic-embed-xs-gguf",  # https://github.com/Snowflake-Labs/arctic-embed
@@ -30,5 +21,5 @@ def simple_config() -> RAGLiteConfig:
     # Use an in-memory SQLite database.
     db_url = "sqlite:///:memory:"
     # Create the config.
-    config = RAGLiteConfig(llm=llm, embedder=embedder, db_url=db_url)
+    config = RAGLiteConfig(embedder=embedder, db_url=db_url)
     return config


### PR DESCRIPTION
This PR selects the LLM and embedder based on the available accelerator.

On CPU it selects Phi 3.1 mini, and on GPU it selects Llama 3.1 8B.

Snowflake's [Arctic-Embed](https://github.com/Snowflake-Labs/arctic-embed) `m-v1.5` model seems to perform nearly equally well as their `l` model, but is much faster than the latter. Therefore, we select this embedder for both CPU and GPU as it is both high quality and economical.