### PR TITLE
fix: avoid pdftext v0.3.11

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -6143,4 +6143,4 @@ ragas = ["ragas"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0"
-content-hash = "64733cd486454d9ab888604e47ceb8ff2fa4f4f38edb5745daec45165e506efb"
+content-hash = "1ae99fe17eed206b710b17380ae77c2f6d87d66f34e59e17d865c4e705b2d0ae"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ version_provider = "poetry"
 # Python:
 python = ">=3.10,<4.0"
 # Markdown conversion:
-pdftext = ">=0.3.10"
+pdftext = ">=0.3.10,!=0.3.11"
 pypandoc-binary = { version = ">=1.13", optional = true }
 scikit-learn = ">=1.4.2"
 # Markdown formatting:


### PR DESCRIPTION
Workaround for https://github.com/VikParuchuri/pdftext/issues/9.