### PR TITLE
fix: extract_with_llm model compatibility and query adapter updates

### DIFF
--- a/src/raglite/_query_adapter.py
+++ b/src/raglite/_query_adapter.py
@@ -1,6 +1,7 @@
 """Compute and update an optimal query adapter."""
 
 import numpy as np
+from sqlalchemy.orm.attributes import flag_modified
 from sqlmodel import Session, col, select
 from tqdm.auto import tqdm
 
@@ -157,6 +158,7 @@ def update_query_adapter(  # noqa: PLR0915, C901
             raise ValueError(error_message)
         # Store the optimal query adapter in the database.
         index_metadata = session.get(IndexMetadata, "default") or IndexMetadata(id="default")
-        index_metadata.metadata_ = {**index_metadata.metadata_, "query_adapter": A_star}
+        index_metadata.metadata_["query_adapter"] = A_star
+        flag_modified(index_metadata, "metadata_")
         session.add(index_metadata)
         session.commit()

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,0 +1,42 @@
+"""Test RAGLite's structured output extraction."""
+
+from typing import ClassVar
+
+import pytest
+from pydantic import BaseModel, Field
+
+from raglite import RAGLiteConfig
+from raglite._extract import extract_with_llm
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(RAGLiteConfig().llm, id="llama_cpp_python"),
+        pytest.param("gpt-4o-mini", id="openai"),
+    ],
+)
+def llm(
+    request: pytest.FixtureRequest,
+) -> str:
+    """Get an LLM to test RAGLite with."""
+    llm: str = request.param
+    return llm
+
+
+def test_extract(llm: str) -> None:
+    """Test extracting structured data."""
+    # Set the LLM.
+    config = RAGLiteConfig(llm=llm)
+
+    # Extract structured data.
+    class LoginResponse(BaseModel):
+        username: str = Field(..., description="The username.")
+        password: str = Field(..., description="The password.")
+        system_prompt: ClassVar[str] = "Extract the username and password from the input."
+
+    username, password = "cypher", "steak"
+    login_response = extract_with_llm(LoginResponse, f"{username} // {password}", config=config)
+    # Validate the response.
+    assert isinstance(login_response, LoginResponse)
+    assert login_response.username == username
+    assert login_response.password == password


### PR DESCRIPTION
two small bugs i noted, which this PR should fix.

1) OpenAI models (and probably more non llama-cpp models) fail in the extract step, since there is a schema key in response format and the system prompt is formatted as a tuple.
2) If you have already created a query adapter, if you then try to updated it again (after generating more evals f.e.), sqlalchemy throws an error. This is because you are trying to add the same key to the metadata_ dir. The fix changes it in-place instead and uses flag_modified to make sure SQLAlchemy updates accordingly when commiting.