### PR TITLE
fix: Insufficient postgres escaping.

### DIFF
--- a/src/raglite/_search.py
+++ b/src/raglite/_search.py
@@ -105,8 +105,8 @@ def keyword_search(
         if db_backend == "postgresql":
             # Convert the query to a tsquery [1].
             # [1] https://www.postgresql.org/docs/current/textsearch-controls.html
-            query_escaped = re.sub(r"[&|!():<>\"]", " ", query)
-            tsv_query = " | ".join(query_escaped.split())
+            words = re.findall(r"\w+", query)
+            tsv_query = " | ".join(words)
             # Perform keyword search with tsvector.
             statement = text(
                 """


### PR DESCRIPTION
The current escaping replacement for Postgres's keyword search is insufficient. Replaced by a more robust one extracting words. (In particular single quotes were not escaped.)