### PR TITLE
feat: let LLM choose whether to retrieve context

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,9 @@ insert_document(Path("Special Relativity.pdf"), config=my_config)
 
 ### 3. Searching and Retrieval-Augmented Generation (RAG)
 
-#### 3.1 Minimal RAG pipeline
+#### 3.1 Dynamically routed RAG
 
-Now you can run a minimal RAG pipeline that consists of adding the user prompt to the message history and streaming the LLM response. Depending on the user prompt, the LLM may choose to retrieve context using RAGLite by invoking it as a tool. If retrieval is necessary, the LLM determines the search query and RAGLite applies hybrid search with reranking to retrieve the most relevant chunk spans (each of which is a list of consecutive chunks). The retrieval results are received by the `on_retrieval` callback, and are also appended to the message history as a tool output. Finally, the LLM response given the RAG context is streamed and the message history is updated with the response:
+Now you can run a dynamically routed RAG pipeline that consists of adding the user prompt to the message history and streaming the LLM response. Depending on the user prompt, the LLM may choose to retrieve context using RAGLite by invoking a retrieval tool. If retrieval is necessary, the LLM determines the search query and RAGLite applies hybrid search with reranking to retrieve the most relevant chunk spans (each of which is a list of consecutive chunks). The retrieval results are sent to the `on_retrieval` callback and are also appended to the message history as a tool output. Finally, the LLM response given the RAG context is streamed and the message history is updated with the assistant response:
 
 ```python
 from raglite import rag
@@ -173,9 +173,9 @@ messages.append({
     "content": "How is intelligence measured?"
 })
 
-# Let the LLM decide whether to search the database by providing a search method as a tool to the LLM.
+# Let the LLM decide whether to search the database by providing a retrieval tool to the LLM.
 # If requested, RAGLite then uses hybrid search and reranking to append RAG context to the message history.
-# Finally, LLM response is streamed and appended to the message history.
+# Finally, assistant response is streamed and appended to the message history.
 chunk_spans = []
 stream = rag(messages, on_retrieval=lambda x: chunk_spans.extend(x), config=my_config)
 for update in stream:
@@ -185,9 +185,9 @@ for update in stream:
 documents = [chunk_span.document for chunk_span in chunk_spans]
 ```
 
-#### 3.2 Basic RAG pipeline
+#### 3.2 Programmable RAG
 
-If you want control over the RAG pipeline, you can run a basic but powerful pipeline that consists of retrieving the most relevant chunk spans with hybrid search and reranking, converting the user prompt to a RAG instruction and appending it to the message history, and finally generating the RAG response:
+If you need manual control over the RAG pipeline, you can run a basic but powerful pipeline that consists of retrieving the most relevant chunk spans with hybrid search and reranking, converting the user prompt to a RAG instruction and appending it to the message history, and finally generating the RAG response:
 
 ```python
 from raglite import create_rag_instruction, rag, retrieve_rag_context
@@ -200,7 +200,7 @@ chunk_spans = retrieve_rag_context(query=user_prompt, num_chunks=5, config=my_co
 messages = []  # Or start with an existing message history.
 messages.append(create_rag_instruction(user_prompt=user_prompt, context=chunk_spans))
 
-# Stream the RAG response:
+# Stream the RAG response and append it to the message history:
 stream = rag(messages, config=my_config)
 for update in stream:
     print(update, end="")
@@ -209,12 +209,10 @@ for update in stream:
 documents = [chunk_span.document for chunk_span in chunk_spans]
 ```
 
-#### 3.3 Advanced RAG pipeline
-
 > [!TIP]
 > 🥇 Reranking can significantly improve the output quality of a RAG application. To add reranking to your application: first search for a larger set of 20 relevant chunks, then rerank them with a [rerankers](https://github.com/AnswerDotAI/rerankers) reranker, and finally keep the top 5 chunks.
 
-In addition to the basic RAG pipeline, RAGLite also offers more advanced control over the pipeline. A full pipeline consists of several steps:
+RAGLite also offers more advanced control over the individual steps of a full RAG pipeline:
 
 1. Searching for relevant chunks with keyword, vector, or hybrid search
 2. Retrieving the chunks from the database
@@ -255,7 +253,7 @@ from raglite import create_rag_instruction
 messages = []  # Or start with an existing message history.
 messages.append(create_rag_instruction(user_prompt=user_prompt, context=chunk_spans))
 
-# Stream the RAG response:
+# Stream the RAG response and append it to the message history:
 from raglite import rag
 
 stream = rag(messages, config=my_config)

--- a/poetry.lock
+++ b/poetry.lock
@@ -2547,13 +2547,13 @@ test = ["coverage", "pytest", "pytest-cov"]
 
 [[package]]
 name = "litellm"
-version = "1.47.1"
+version = "1.48.10"
 description = "Library to easily interface with LLM API providers"
 optional = false
 python-versions = "!=2.7.*,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,!=3.7.*,>=3.8"
 files = [
-    {file = "litellm-1.47.1-py3-none-any.whl", hash = "sha256:baa1961287ee398c937e8a5ecd1fcb821ea8f91cbd1f4757b6c19d7bcc84d4fd"},
-    {file = "litellm-1.47.1.tar.gz", hash = "sha256:51d1eb353573ddeac75c45b66147f533f64f231540667ea30b63edb9a2af15ce"},
+    {file = "litellm-1.48.10-py3-none-any.whl", hash = "sha256:752efd59747a0895f4695d025c66f0b2258d80a61175f7cfa41dbe4894ef95e1"},
+    {file = "litellm-1.48.10.tar.gz", hash = "sha256:0a4ff75da78e66baeae0658ad8de498298310a5efda74c3d840ce2b013e8401d"},
 ]
 
 [package.dependencies]
@@ -6813,4 +6813,4 @@ ragas = ["ragas"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0"
-content-hash = "ff8a8596ac88ae5406234f08810e2e4d654714af0aa3663451e988a2cf6ef51e"
+content-hash = "b3a14066711fe4caec356d0aa18514495d44ac253371d2560fc0c5aea890aaef"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ scipy = ">=1.5.0"
 spacy = ">=3.7.0,<3.8.0"
 # Large Language Models:
 huggingface-hub = ">=0.22.0"
-litellm = ">=1.47.1"
+litellm = ">=1.48.4"
 llama-cpp-python = ">=0.3.2"
 pydantic = ">=2.7.0"
 # Approximate Nearest Neighbors:

--- a/src/raglite/_chainlit.py
+++ b/src/raglite/_chainlit.py
@@ -91,8 +91,7 @@ async def handle_message(user_message: cl.Message) -> None:
     async for token in async_rag(messages, config=config):
         await assistant_message.stream_token(token)
     # Append RAG sources if any.
-    if messages[-2]["role"] == "tool":
-        rag_context = json.loads(messages[-2]["content"])
+    if messages[-2]["role"] == "tool" and (rag_context := json.loads(messages[-2]["content"])):
         rag_sources: dict[str, list[str]] = {}
         for document in rag_context["documents"]:
             rag_sources.setdefault(document["source"], [])

--- a/src/raglite/_extract.py
+++ b/src/raglite/_extract.py
@@ -34,13 +34,12 @@ def extract_with_llm(
     # Load the default config if not provided.
     config = config or RAGLiteConfig()
     # Check if the LLM supports the response format.
-    llm_provider = "llama-cpp-python" if config.embedder.startswith("llama-cpp") else None
     llm_supports_response_format = "response_format" in (
-        get_supported_openai_params(model=config.llm, custom_llm_provider=llm_provider) or []
+        get_supported_openai_params(model=config.llm) or []
     )
     # Update the system prompt with the JSON schema of the return type to help the LLM.
     system_prompt = getattr(return_type, "system_prompt", "").strip()
-    if not llm_supports_response_format or llm_provider == "llama-cpp-python":
+    if not llm_supports_response_format or config.llm.startswith("llama-cpp-python"):
         system_prompt += f"\n\nFormat your response according to this JSON schema:\n{return_type.model_json_schema()!s}"
     # Constrain the reponse format to the JSON schema if it's supported by the LLM [1]. Strict mode
     # is disabled by default because it only supports a subset of JSON schema features [2].

--- a/src/raglite/_litellm.py
+++ b/src/raglite/_litellm.py
@@ -128,7 +128,7 @@ class LlamaCppPythonLLM(CustomLLM):
         llm.set_cache(LlamaRAMCache())
         # Register the model info with LiteLLM.
         model_info = {
-            model: {
+            repo_id_filename: {
                 "max_tokens": llm.n_ctx(),
                 "max_input_tokens": llm.n_ctx(),
                 "max_output_tokens": None,
@@ -319,8 +319,7 @@ def get_context_size(config: RAGLiteConfig, *, fallback: int = 2048) -> int:
     if config.llm.startswith("llama-cpp-python"):
         _ = LlamaCppPythonLLM.llm(config.llm)
     # Attempt to read the context size from LiteLLM's model info.
-    llm_provider = "llama-cpp-python" if config.llm.startswith("llama-cpp") else None
-    model_info = get_model_info(config.llm, custom_llm_provider=llm_provider)
+    model_info = get_model_info(config.llm)
     max_tokens = model_info.get("max_tokens")
     if isinstance(max_tokens, int) and max_tokens > 0:
         return max_tokens
@@ -343,8 +342,7 @@ def get_embedding_dim(config: RAGLiteConfig, *, fallback: bool = True) -> int:
     if config.embedder.startswith("llama-cpp-python"):
         _ = LlamaCppPythonLLM.llm(config.embedder, embedding=True)
     # Attempt to read the embedding dimension from LiteLLM's model info.
-    llm_provider = "llama-cpp-python" if config.embedder.startswith("llama-cpp") else None
-    model_info = get_model_info(config.embedder, custom_llm_provider=llm_provider)
+    model_info = get_model_info(config.embedder)
     embedding_dim = model_info.get("output_vector_size")
     if isinstance(embedding_dim, int) and embedding_dim > 0:
         return embedding_dim

--- a/src/raglite/_rag.py
+++ b/src/raglite/_rag.py
@@ -92,8 +92,7 @@ def _get_tools(
     # Check if messages already contain RAG context or if the LLM supports tool use.
     final_message = messages[-1].get("content", "")
     messages_contain_rag_context = any(s in final_message for s in ("</document>", "from_chunk_id"))
-    llm_provider = "llama-cpp-python" if config.llm.startswith("llama-cpp") else None
-    llm_supports_function_calling = supports_function_calling(config.llm, llm_provider)
+    llm_supports_function_calling = supports_function_calling(config.llm)
     if not messages_contain_rag_context and not llm_supports_function_calling:
         error_message = "You must either explicitly provide RAG context in the last message, or use an LLM that supports function calling."
         raise ValueError(error_message)
@@ -107,7 +106,7 @@ def _get_tools(
                 "description": "The `expert` boolean MUST be true if the question requires domain-specific or expert-level knowledge to answer, and false otherwise.",
             }
         }
-        if llm_provider == "llama-cpp-python"
+        if config.llm.startswith("llama-cpp-python")
         else {}
     )
     tools: list[dict[str, Any]] | None = (

--- a/src/raglite/_rag.py
+++ b/src/raglite/_rag.py
@@ -1,9 +1,17 @@
 """Retrieval-augmented generation."""
 
+import json
 from collections.abc import AsyncIterator, Iterator
+from typing import Any
 
 import numpy as np
-from litellm import acompletion, completion
+from litellm import (  # type: ignore[attr-defined]
+    ChatCompletionMessageToolCall,
+    acompletion,
+    completion,
+    stream_chunk_builder,
+    supports_function_calling,
+)
 
 from raglite._config import RAGLiteConfig
 from raglite._database import ChunkSpan
@@ -70,25 +78,197 @@ def create_rag_instruction(
     return message
 
 
+def _clip(messages: list[dict[str, str]], max_tokens: int) -> list[dict[str, str]]:
+    """Left clip a messages array to avoid hitting the context limit."""
+    cum_tokens = np.cumsum([len(message.get("content") or "") // 3 for message in messages][::-1])
+    first_message = -np.searchsorted(cum_tokens, max_tokens)
+    return messages[first_message:]
+
+
+def _get_tools(
+    messages: list[dict[str, str]], config: RAGLiteConfig
+) -> tuple[list[dict[str, Any]] | None, dict[str, Any] | str | None]:
+    """Get tools to search the knowledge base if no RAG context is provided in the messages."""
+    # Check if messages already contain RAG context or if the LLM supports tool use.
+    final_message = messages[-1].get("content", "")
+    messages_contain_rag_context = any(s in final_message for s in ("</document>", "from_chunk_id"))
+    llm_provider = "llama-cpp-python" if config.llm.startswith("llama-cpp") else None
+    llm_supports_function_calling = supports_function_calling(config.llm, llm_provider)
+    if not messages_contain_rag_context and not llm_supports_function_calling:
+        error_message = "You must either explicitly provide RAG context in the last message, or use an LLM that supports function calling."
+        raise ValueError(error_message)
+    # Add a tool to search the knowledge base if no RAG context is provided in the messages. Because
+    # llama-cpp-python cannot stream tool_use='auto' yet, we use a workaround that forces the LLM
+    # to use a tool, but allows it to skip the search.
+    auto_tool_use_workaround = (
+        {
+            "skip": {
+                "type": "boolean",
+                "description": "True if a satisfactory answer can be provided without the knowledge base, false otherwise.",
+            }
+        }
+        if llm_provider == "llama-cpp-python"
+        else {}
+    )
+    tools: list[dict[str, Any]] | None = (
+        [
+            {
+                "type": "function",
+                "function": {
+                    "name": "search_knowledge_base",
+                    "description": "Search the knowledge base. Note: only use this tool if not enough information is available to provide an answer.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            **auto_tool_use_workaround,
+                            "query": {
+                                "type": ["string", "null"],
+                                "description": "\n".join(  # noqa: FLY002
+                                    [
+                                        "The query string to search the knowledge base with.",
+                                        "The query string MUST satisfy ALL of the following criteria:"
+                                        "- The query string MUST be a precise question in the user's language.",
+                                        "- The query string MUST resolve all pronouns to explicit nouns from the conversation history.",
+                                        "- The query string MUST be `null` if `skip` is `true`.",
+                                    ]
+                                ),
+                            },
+                        },
+                        "required": [*list(auto_tool_use_workaround), "query"],
+                        "additionalProperties": False,
+                    },
+                },
+            }
+        ]
+        if not messages_contain_rag_context
+        else None
+    )
+    tool_choice: dict[str, Any] | str | None = (
+        (
+            {"type": "function", "function": {"name": "search_knowledge_base"}}
+            if auto_tool_use_workaround
+            else "auto"
+        )
+        if tools
+        else None
+    )
+    return tools, tool_choice
+
+
+def _run_tools(
+    tool_calls: list[ChatCompletionMessageToolCall], config: RAGLiteConfig
+) -> list[dict[str, Any]]:
+    """Run tools to search the knowledge base for RAG context."""
+    tool_messages: list[dict[str, Any]] = []
+    for tool_call in tool_calls:
+        if tool_call.function.name == "search_knowledge_base":
+            kwargs = json.loads(tool_call.function.arguments)
+            kwargs["config"] = config
+            skip = kwargs.pop("skip", False)
+            tool_messages.append(
+                {
+                    "role": "tool",
+                    "content": '{{"documents": [{elements}]}}'.format(
+                        elements=", ".join(
+                            chunk_span.to_json(index=i + 1)
+                            for i, chunk_span in enumerate(retrieve_rag_context(**kwargs))
+                        )
+                    )
+                    if not skip and kwargs["query"]
+                    else "{}",
+                    "tool_call_id": tool_call.id,
+                }
+            )
+        else:
+            error_message = f"Unknown function `{tool_call.function.name}`."
+            raise ValueError(error_message)
+    return tool_messages
+
+
 def rag(messages: list[dict[str, str]], *, config: RAGLiteConfig) -> Iterator[str]:
-    # Truncate the oldest messages so we don't hit the context limit.
+    # If the final message does not contain RAG context, get a tool to search the knowledge base.
     max_tokens = get_context_size(config)
-    cum_tokens = np.cumsum([len(message.get("content", "")) // 3 for message in messages][::-1])
-    messages = messages[-np.searchsorted(cum_tokens, max_tokens) :]
-    # Stream the LLM response.
-    stream = completion(model=config.llm, messages=messages, stream=True)
-    for output in stream:
-        token: str = output["choices"][0]["delta"].get("content") or ""
-        yield token
+    tools, tool_choice = _get_tools(messages, config)
+    # Stream the LLM response, which is either a tool call request or an assistant response.
+    chunks = []
+    clipped_messages = _clip(messages, max_tokens)
+    if tools and config.llm.startswith("llama-cpp-python"):
+        # Help llama.cpp LLMs plan their response by providing a JSON schema for the tool call.
+        clipped_messages[-1]["content"] += (
+            f"\n\nDecide whether to use or skip these tools in your response:\n{json.dumps(tools)}"
+        )
+    stream = completion(
+        model=config.llm,
+        messages=clipped_messages,
+        tools=tools,
+        tool_choice=tool_choice,
+        stream=True,
+    )
+    for chunk in stream:
+        chunks.append(chunk)
+        if isinstance(token := chunk.choices[0].delta.content, str):
+            yield token
+    # Check if there are tools to be called.
+    response = stream_chunk_builder(chunks, messages)
+    tool_calls = response.choices[0].message.tool_calls  # type: ignore[union-attr]
+    if tool_calls:
+        # Add the tool call request to the message array.
+        messages.append(response.choices[0].message.to_dict())  # type: ignore[arg-type,union-attr]
+        # Run the tool calls to retrieve the RAG context and append the output to the message array.
+        messages.extend(_run_tools(tool_calls, config))
+        # Stream the assistant response.
+        chunks = []
+        stream = completion(model=config.llm, messages=_clip(messages, max_tokens), stream=True)
+        for chunk in stream:
+            chunks.append(chunk)
+            if isinstance(token := chunk.choices[0].delta.content, str):
+                yield token
+    # Append the assistant response to the message array.
+    response = stream_chunk_builder(chunks, messages)
+    messages.append(response.choices[0].message.to_dict())  # type: ignore[arg-type,union-attr]
 
 
 async def async_rag(messages: list[dict[str, str]], *, config: RAGLiteConfig) -> AsyncIterator[str]:
-    # Truncate the oldest messages so we don't hit the context limit.
+    # If the final message does not contain RAG context, get a tool to search the knowledge base.
     max_tokens = get_context_size(config)
-    cum_tokens = np.cumsum([len(message.get("content", "")) // 3 for message in messages][::-1])
-    messages = messages[-np.searchsorted(cum_tokens, max_tokens) :]
-    # Asynchronously stream the LLM response.
-    async_stream = await acompletion(model=config.llm, messages=messages, stream=True)
-    async for output in async_stream:
-        token: str = output["choices"][0]["delta"].get("content") or ""
-        yield token
+    tools, tool_choice = _get_tools(messages, config)
+    # Asynchronously stream the LLM response, which is either a tool call or an assistant response.
+    chunks = []
+    clipped_messages = _clip(messages, max_tokens)
+    if tools and config.llm.startswith("llama-cpp-python"):
+        # Help llama.cpp LLMs plan their response by providing a JSON schema for the tool call.
+        clipped_messages[-1]["content"] += (
+            f"\n\nDecide whether to use or skip these tools in your response:\n{json.dumps(tools)}"
+        )
+    async_stream = await acompletion(
+        model=config.llm,
+        messages=clipped_messages,
+        tools=tools,
+        tool_choice=tool_choice,
+        stream=True,
+    )
+    async for chunk in async_stream:
+        chunks.append(chunk)
+        if isinstance(token := chunk.choices[0].delta.content, str):
+            yield token
+    # Check if there are tools to be called.
+    response = stream_chunk_builder(chunks, messages)
+    tool_calls = response.choices[0].message.tool_calls  # type: ignore[union-attr]
+    if tool_calls:
+        # Add the tool call requests to the message array.
+        messages.append(response.choices[0].message.to_dict())  # type: ignore[arg-type,union-attr]
+        # Run the tool calls to retrieve the RAG context and append the output to the message array.
+        # TODO: Make this async.
+        messages.extend(_run_tools(tool_calls, config))
+        # Asynchronously stream the assistant response.
+        chunks = []
+        async_stream = await acompletion(
+            model=config.llm, messages=_clip(messages, max_tokens), stream=True
+        )
+        async for chunk in async_stream:
+            chunks.append(chunk)
+            if isinstance(token := chunk.choices[0].delta.content, str):
+                yield token
+    # Append the assistant response to the message array.
+    response = stream_chunk_builder(chunks, messages)
+    messages.append(response.choices[0].message.to_dict())  # type: ignore[arg-type,union-attr]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,25 +76,19 @@ def database(request: pytest.FixtureRequest) -> str:
     params=[
         pytest.param(
             (
+                "llama-cpp-python/bartowski/Llama-3.2-3B-Instruct-GGUF/*Q4_K_M.gguf@4096",
+                "llama-cpp-python/lm-kit/bge-m3-gguf/*Q4_K_M.gguf@1024",  # More context degrades performance.
+            ),
+            id="llama32_3B-bge_m3",
+        ),
+        pytest.param(
+            (
                 "llama-cpp-python/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/*Q4_K_M.gguf@4096",
                 "llama-cpp-python/lm-kit/bge-m3-gguf/*Q4_K_M.gguf@1024",  # More context degrades performance.
             ),
             id="llama31_8B-bge_m3",
             marks=pytest.mark.skipif(
                 not is_accelerator_available(), reason="No accelerator available"
-            ),
-        ),
-        pytest.param(
-            (
-                "gpt-4o-mini",
-                "llama-cpp-python/lm-kit/bge-m3-gguf/*Q4_K_M.gguf@1024",  # More context degrades performance.
-            ),
-            id="gpt_4o_mini-bge_m3",
-            marks=pytest.mark.skipif(
-                not is_openai_available() or is_accelerator_available(),
-                reason="OpenAI API key is not set"
-                if not is_openai_available()
-                else "Local LLM available",
             ),
         ),
         pytest.param(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,16 +82,6 @@ def database(request: pytest.FixtureRequest) -> str:
             id="llama32_3B-bge_m3",
         ),
         pytest.param(
-            (
-                "llama-cpp-python/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/*Q4_K_M.gguf@4096",
-                "llama-cpp-python/lm-kit/bge-m3-gguf/*Q4_K_M.gguf@1024",  # More context degrades performance.
-            ),
-            id="llama31_8B-bge_m3",
-            marks=pytest.mark.skipif(
-                not is_accelerator_available(), reason="No accelerator available"
-            ),
-        ),
-        pytest.param(
             ("gpt-4o-mini", "text-embedding-3-small"),
             id="gpt_4o_mini-text_embedding_3_small",
             marks=pytest.mark.skipif(not is_openai_available(), reason="OpenAI API key is not set"),

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -29,7 +29,7 @@ def test_extract(llm: str, strict: bool) -> None:  # noqa: FBT001
     # Extract structured data.
     username, password = "cypher", "steak"
     login_response = extract_with_llm(
-        LoginResponse, f"{username} // {password}", strict=strict, config=config
+        LoginResponse, f"username: {username}\npassword: {password}", strict=strict, config=config
     )
     # Validate the response.
     assert isinstance(login_response, LoginResponse)

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -9,18 +9,6 @@ from raglite import RAGLiteConfig
 from raglite._extract import extract_with_llm
 
 
-@pytest.fixture(
-    params=[
-        pytest.param(RAGLiteConfig().llm, id="llama_cpp_python"),
-        pytest.param("gpt-4o-mini", id="openai"),
-    ]
-)
-def llm(request: pytest.FixtureRequest) -> str:
-    """Get an LLM to test RAGLite with."""
-    llm: str = request.param
-    return llm
-
-
 @pytest.mark.parametrize(
     "strict", [pytest.param(False, id="strict=False"), pytest.param(True, id="strict=True")]
 )

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -13,7 +13,7 @@ from raglite._rag import rag
 def test_rag_manual(raglite_test_config: RAGLiteConfig) -> None:
     """Test Retrieval-Augmented Generation with manual retrieval."""
     # Answer a question with manual RAG.
-    user_prompt = "What is special relativity's definition of 'simultaneous events'?"
+    user_prompt = "How does Einstein define 'simultaneous events' in his special relativity paper?"
     chunk_spans = retrieve_rag_context(query=user_prompt, config=raglite_test_config)
     messages = [create_rag_instruction(user_prompt, context=chunk_spans)]
     stream = rag(messages, config=raglite_test_config)
@@ -29,22 +29,23 @@ def test_rag_manual(raglite_test_config: RAGLiteConfig) -> None:
 def test_rag_auto_with_retrieval(raglite_test_config: RAGLiteConfig) -> None:
     """Test Retrieval-Augmented Generation with automatic retrieval."""
     # Answer a question that requires RAG.
-    user_prompt = "What is special relativity's definition of 'simultaneous events'?"
+    user_prompt = "How does Einstein define 'simultaneous events' in his special relativity paper?"
     messages = [{"role": "user", "content": user_prompt}]
     stream = rag(messages, config=raglite_test_config)
     answer = ""
     for update in stream:
         assert isinstance(update, str)
         answer += update
-    assert "simultaneous" in answer.lower()
+    assert "event" in answer.lower()
     # Verify that RAG context was retrieved automatically.
     assert [message["role"] for message in messages] == ["user", "assistant", "tool", "assistant"]
+    assert json.loads(messages[-2]["content"])
 
 
 def test_rag_auto_without_retrieval(raglite_test_config: RAGLiteConfig) -> None:
     """Test Retrieval-Augmented Generation with automatic retrieval."""
     # Answer a question that does not require RAG.
-    user_prompt = "Yes or no: is 'Veni, vidi, vici' a Latin phrase?"
+    user_prompt = "Is 7 a prime number? Answer with Yes or No only."
     messages = [{"role": "user", "content": user_prompt}]
     stream = rag(messages, config=raglite_test_config)
     answer = ""

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -44,7 +44,7 @@ def test_rag_auto_with_retrieval(raglite_test_config: RAGLiteConfig) -> None:
 def test_rag_auto_without_retrieval(raglite_test_config: RAGLiteConfig) -> None:
     """Test Retrieval-Augmented Generation with automatic retrieval."""
     # Answer a question that does not require RAG.
-    user_prompt = "Is 7 a prime number?"
+    user_prompt = "Yes or no: is 'Veni, vidi, vici' a Latin phrase?"
     messages = [{"role": "user", "content": user_prompt}]
     stream = rag(messages, config=raglite_test_config)
     answer = ""

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -1,9 +1,6 @@
 """Test RAGLite's RAG functionality."""
 
-import os
-
-import pytest
-from llama_cpp import llama_supports_gpu_offload
+import json
 
 from raglite import (
     RAGLiteConfig,
@@ -13,16 +10,10 @@ from raglite import (
 from raglite._rag import rag
 
 
-def is_accelerator_available() -> bool:
-    """Check if an accelerator is available."""
-    return llama_supports_gpu_offload() or (os.cpu_count() or 1) >= 8  # noqa: PLR2004
-
-
-@pytest.mark.skipif(not is_accelerator_available(), reason="No accelerator available")
-def test_rag(raglite_test_config: RAGLiteConfig) -> None:
-    """Test Retrieval-Augmented Generation."""
-    # Answer a question with RAG.
-    user_prompt = "What does it mean for two events to be simultaneous?"
+def test_rag_manual(raglite_test_config: RAGLiteConfig) -> None:
+    """Test Retrieval-Augmented Generation with manual retrieval."""
+    # Answer a question with manual RAG.
+    user_prompt = "What is special relativity's definition of 'simultaneous events'?"
     chunk_spans = retrieve_rag_context(query=user_prompt, config=raglite_test_config)
     messages = [create_rag_instruction(user_prompt, context=chunk_spans)]
     stream = rag(messages, config=raglite_test_config)
@@ -30,4 +21,42 @@ def test_rag(raglite_test_config: RAGLiteConfig) -> None:
     for update in stream:
         assert isinstance(update, str)
         answer += update
+    assert "event" in answer.lower()
+    # Verify that no RAG context was retrieved through tool use.
+    assert [message["role"] for message in messages] == ["user", "assistant"]
+
+
+def test_rag_auto_with_retrieval(raglite_test_config: RAGLiteConfig) -> None:
+    """Test Retrieval-Augmented Generation with automatic retrieval."""
+    # Answer a question that requires RAG.
+    user_prompt = "What is special relativity's definition of 'simultaneous events'?"
+    messages = [{"role": "user", "content": user_prompt}]
+    stream = rag(messages, config=raglite_test_config)
+    answer = ""
+    for update in stream:
+        assert isinstance(update, str)
+        answer += update
     assert "simultaneous" in answer.lower()
+    # Verify that RAG context was retrieved automatically.
+    assert [message["role"] for message in messages] == ["user", "assistant", "tool", "assistant"]
+
+
+def test_rag_auto_without_retrieval(raglite_test_config: RAGLiteConfig) -> None:
+    """Test Retrieval-Augmented Generation with automatic retrieval."""
+    # Answer a question that does not require RAG.
+    user_prompt = "Is 7 a prime number?"
+    messages = [{"role": "user", "content": user_prompt}]
+    stream = rag(messages, config=raglite_test_config)
+    answer = ""
+    for update in stream:
+        assert isinstance(update, str)
+        answer += update
+    assert "yes" in answer.lower()
+    # Verify that no RAG context was retrieved.
+    if raglite_test_config.llm.startswith("llama-cpp-python"):
+        # Llama.cpp does not support streaming tool_choice="auto" yet, so instead we verify that the
+        # LLM indicates that the tool call request may be skipped by checking that content is empty.
+        assert [msg["role"] for msg in messages] == ["user", "assistant", "tool", "assistant"]
+        assert not json.loads(messages[-2]["content"])
+    else:
+        assert [msg["role"] for msg in messages] == ["user", "assistant"]


### PR DESCRIPTION
Changes:
- Add support for tool use to the llama.cpp LiteLLM integration.
- The `rag` or `async_rag` functions now update the message history with tool use and the assistant response.
- Let LLM choose whether to retrieve context through tool use. Details:
    - Tool use is skipped if RAG context is already provided.
    - Llama.cpp models cannot stream the response with `tool_choice="auto"` (which lets the LLM choose whether or not to call a tool), so we add a workaround that forces tool use but lets them skip tool execution with a `skip=True` argument.
    - To help llama.cpp models plan their tool use response, the final message is extended with the tools' JSON schema.
- Fix registering of llama.cpp model_info with LiteLLM.
- Improve RAG generation test cases.
- Improve LLM-embedder test coverage.