### PR TITLE
fix(deps): exclude litellm versions that break get_model_info

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -6243,4 +6243,4 @@ ragas = ["ragas"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0"
-content-hash = "633bee82da33bf0d3f2bd3b78c85f71dbe56fb41016a5fe8a9d67bc79ebde73c"
+content-hash = "79fc9846f604c547e4390dfe8686431f2f5416044f57f748eba3738fe8aba13c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ scipy = ">=1.5.0"
 wtpsplit-lite = ">=0.1.0"
 # Large Language Models:
 huggingface-hub = ">=0.22.0"
-litellm = ">=1.48.4"
+litellm = ">=1.48.4,<1.56.10"
 llama-cpp-python = ">=0.3.2"
 pydantic = ">=2.7.0"
 # Approximate Nearest Neighbors:


### PR DESCRIPTION
LiteLLM v1.56.10 breaks `get_model_info` for custom providers: https://github.com/BerriAI/litellm/issues/7575.

This PR excludes v1.56.10 and up until they release a new version that fixes that issue.