### PR TITLE
feat: make importing faster

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ memory-profiler = ">=0.61.0"
 pdoc = ">=14.4.0"
 
 [tool.poetry.scripts] # https://python-poetry.org/docs/pyproject/#scripts
-raglite = "raglite:cli"
+raglite = "raglite._cli:cli"
 
 [tool.coverage.report] # https://coverage.readthedocs.io/en/latest/config.html#report
 fail_under = 50

--- a/src/raglite/__init__.py
+++ b/src/raglite/__init__.py
@@ -1,6 +1,5 @@
 """RAGLite."""
 
-from raglite._cli import cli
 from raglite._config import RAGLiteConfig
 from raglite._eval import answer_evals, evaluate, insert_evals
 from raglite._insert import insert_document
@@ -38,6 +37,4 @@ __all__ = [
     "insert_evals",
     "answer_evals",
     "evaluate",
-    # CLI
-    "cli",
 ]


### PR DESCRIPTION
Main offenders that make `import raglite` slow:
1. `import litellm` takes ~1s (https://github.com/BerriAI/litellm/issues/7605).
2. Loading a `BaseSettings` takes ~1s.

This PR changes the exports so that `BaseSettings` are only loaded when actually using the CLI. After this PR, `import raglite` should be reduced to about ~1.9s.