### PR TITLE
feat: add ability to directly insert Markdown content into the database

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ from raglite import RAGLiteConfig
 
 # Example 'remote' config with a PostgreSQL database and an OpenAI LLM:
 my_config = RAGLiteConfig(
-    db_url="postgresql://my_username:my_password@my_host:5432/my_database"
+    db_url="postgresql://my_username:my_password@my_host:5432/my_database",
     llm="gpt-4o-mini",  # Or any LLM supported by LiteLLM.
     embedder="text-embedding-3-large",  # Or any embedder supported by LiteLLM.
 )

--- a/README.md
+++ b/README.md
@@ -144,13 +144,21 @@ my_config = RAGLiteConfig(
 
 Next, insert some documents into the database. RAGLite will take care of the [conversion to Markdown](src/raglite/_markdown.py), [optimal level 4 semantic chunking](src/raglite/_split_chunks.py), and [multi-vector embedding with late chunking](src/raglite/_embed.py):
 
+
 ```python
-# Insert documents:
+# Insert documents with a file path:
 from pathlib import Path
 from raglite import insert_document
 
 insert_document(Path("On the Measure of Intelligence.pdf"), config=my_config)
 insert_document(Path("Special Relativity.pdf"), config=my_config)
+
+# Insert documents with a Markdown string and filename:
+markdown_content = """
+# Special Relativity
+Special Relativity is a theory by Albert Einstein that explains the relationship between space and time.
+"""
+insert_document(markdown_content, filename="SpecialRelativity.md", config=my_config)
 ```
 
 ### 3. Retrieval-Augmented Generation (RAG)

--- a/README.md
+++ b/README.md
@@ -146,19 +146,20 @@ Next, insert some documents into the database. RAGLite will take care of the [co
 
 
 ```python
-# Insert documents with a file path:
+# Insert a document given its file path:
 from pathlib import Path
 from raglite import insert_document
 
 insert_document(Path("On the Measure of Intelligence.pdf"), config=my_config)
 insert_document(Path("Special Relativity.pdf"), config=my_config)
 
-# Insert documents with a Markdown string and filename:
+# Insert a document given its Markdown content:
 markdown_content = """
-# Special Relativity
-Special Relativity is a theory by Albert Einstein that explains the relationship between space and time.
+# ON THE ELECTRODYNAMICS OF MOVING BODIES
+## By A. EINSTEIN  June 30, 1905
+It is known that Maxwell
 """
-insert_document(markdown_content, filename="SpecialRelativity.md", config=my_config)
+insert_document(markdown_content, config=my_config)
 ```
 
 ### 3. Retrieval-Augmented Generation (RAG)

--- a/src/raglite/_database.py
+++ b/src/raglite/_database.py
@@ -69,28 +69,26 @@ class Document(SQLModel, table=True):
 
     @staticmethod
     def from_markdown(content: str, filename: str | None, **kwargs: Any) -> "Document":
-        """Create a document from markdown content.
+        """Create a document from Markdown content.
 
-        Args:
-            content: The markdown content as a string
-            filename: Optional filename (defaults to timestamp-based name)
-            **kwargs: Additional metadata to store
+        Parameters
+        ----------
+        content
+            The document's content as a Markdown string.
+        filename
+            The document filename to use. If not provided, the first line of the content is used.
+        kwargs
+            Any additional metadata to store.
+
+        Returns
+        -------
+        Document
+            A document.
         """
-        # Generate a filename if not provided
-        if filename is None:
-            timestamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d_%H%M%S")
-            filename = f"markdown_{timestamp}.md"
-
         return Document(
             id=hash_bytes(content.encode()),
-            filename=filename,
-            metadata_={
-                "size": len(content),
-                "created": datetime.datetime.now(datetime.timezone.utc).timestamp(),
-                "modified": datetime.datetime.now(datetime.timezone.utc).timestamp(),
-                "source": "markdown_direct",
-                **kwargs,
-            },
+            filename=filename or (content.strip().split("\n", 1)[0].strip() + ".md"),
+            metadata_={"size": len(content.encode()), **kwargs},
         )
 
 

--- a/src/raglite/_database.py
+++ b/src/raglite/_database.py
@@ -67,6 +67,32 @@ class Document(SQLModel, table=True):
             },
         )
 
+    @staticmethod
+    def from_markdown(content: str, filename: str | None, **kwargs: Any) -> "Document":
+        """Create a document from markdown content.
+
+        Args:
+            content: The markdown content as a string
+            filename: Optional filename (defaults to timestamp-based name)
+            **kwargs: Additional metadata to store
+        """
+        # Generate a filename if not provided
+        if filename is None:
+            timestamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d_%H%M%S")
+            filename = f"markdown_{timestamp}.md"
+
+        return Document(
+            id=hash_bytes(content.encode()),
+            filename=filename,
+            metadata_={
+                "size": len(content),
+                "created": datetime.datetime.now(datetime.timezone.utc).timestamp(),
+                "modified": datetime.datetime.now(datetime.timezone.utc).timestamp(),
+                "source": "markdown_direct",
+                **kwargs,
+            },
+        )
+
 
 class Chunk(SQLModel, table=True):
     """A document chunk."""

--- a/src/raglite/_insert.py
+++ b/src/raglite/_insert.py
@@ -65,23 +65,49 @@ def _create_chunk_records(
     return chunk_records, chunk_embedding_records
 
 
-def insert_document(doc_path: Path, *, config: RAGLiteConfig | None = None) -> None:  # noqa: PLR0915
-    """Insert a document into the database and update the index."""
+def insert_document(  # noqa: PLR0915
+    source: Path | str,
+    *,
+    filename: str | None = None,
+    config: RAGLiteConfig | None = None,
+) -> None:
+    """Insert a document into the database and update the index.
+
+    Args:
+        source (Path | str): Document source, either a file path or a markdown string content.
+        filename (str | None): The name of the file, used if `source` is a string. Defaults to None.
+        config (RAGLiteConfig | None): Configuration settings for insertion. Defaults to None.
+
+    Returns
+    -------
+        None
+    """
     # Use the default config if not provided.
     config = config or RAGLiteConfig()
+
     # Preprocess the document into chunks and chunk embeddings.
     with tqdm(total=6, unit="step", dynamic_ncols=True) as pbar:
         pbar.set_description("Initializing database")
         engine = create_database_engine(config)
-        document_record = Document.from_path(doc_path)
+        pbar.update(1)
+        # Create document record based on input type
+        pbar.set_description(
+            "Converting to Markdown" if isinstance(source, Path) else "Using inputted Markdown"
+        )
+
+        document_record, doc = (
+            (Document.from_path(source), document_to_markdown(source))
+            if isinstance(source, Path)
+            else (Document.from_markdown(source, filename=filename), source)
+        )
+
         with Session(engine) as session:  # Exit early if the document is already in the database.
             if session.get(Document, document_record.id) is not None:
-                pbar.update(6)
+                pbar.set_description("Document already exists in the database -> Skipping action.")
+                pbar.update(5)
                 pbar.close()
                 return
-        pbar.update(1)
-        pbar.set_description("Converting to Markdown")
-        doc = document_to_markdown(doc_path)
+
         pbar.update(1)
         pbar.set_description("Splitting sentences")
         sentences = split_sentences(doc, max_len=config.chunk_max_size)


### PR DESCRIPTION
This PR introduces the ability to directly pass markdown content as input when inserting documents into the database. Previously, only file paths (e.g., PDF) were supported, but with this change, users can now input a markdown string directly, making the process more flexible.

**Changes:**

1. New Method: Created a method to generate a Document object from markdown content.
2.  Modified insert_document Function: Updated the insert_document function to include markdown content.
3. Updated the Readme to explain the new feature

This change improves the workflow for users who need to insert markdown content directly, without requiring it to be written to a file first.


**Testing:**
This PR has been tested locally with a local setup. 
Markdown data is correctly stored in the local sqlite database with the insert document functionality. 