### PR TITLE
feat: make llama-cpp-python an optional dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1076,7 +1076,7 @@ profile = ["gprof2dot (>=2022.7.29)"]
 name = "diskcache"
 version = "5.6.3"
 description = "Disk Cache -- Disk and file backed persistent cache."
-optional = false
+optional = true
 python-versions = ">=3"
 files = [
     {file = "diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19"},
@@ -2457,7 +2457,7 @@ pydantic = ">=1,<3"
 name = "llama-cpp-python"
 version = "0.3.2"
 description = "Python bindings for the llama.cpp library"
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "llama_cpp_python-0.3.2.tar.gz", hash = "sha256:8fbf246a55a999f45015ed0d48f91b4ae04ae959827fac1cd6ac6ec65aed2e2f"},
@@ -6237,10 +6237,11 @@ type = ["pytest-mypy"]
 
 [extras]
 chainlit = ["chainlit"]
+llama-cpp-python = ["llama-cpp-python"]
 pandoc = ["pypandoc-binary"]
 ragas = ["ragas"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0"
-content-hash = "79fc9846f604c547e4390dfe8686431f2f5416044f57f748eba3738fe8aba13c"
+content-hash = "90303315441ee88e05111cd6387f6fa279cbe9cb52ffe0129b8b5f0fe2cf29f7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ wtpsplit-lite = ">=0.1.0"
 # Large Language Models:
 huggingface-hub = ">=0.22.0"
 litellm = ">=1.48.4,<1.56.10"
-llama-cpp-python = ">=0.3.2"
+llama-cpp-python = { version = ">=0.3.2", optional = true }
 pydantic = ">=2.7.0"
 # Approximate Nearest Neighbors:
 pynndescent = ">=0.5.12"
@@ -61,6 +61,7 @@ packaging = ">=23.0"
 
 [tool.poetry.extras] # https://python-poetry.org/docs/pyproject/#extras
 chainlit = ["chainlit"]
+llama-cpp-python = ["llama-cpp-python"]
 pandoc = ["pypandoc-binary"]
 ragas = ["ragas"]
 
@@ -130,7 +131,7 @@ target-version = "py310"
 
 [tool.ruff.lint]
 select = ["A", "ASYNC", "B", "BLE", "C4", "C90", "D", "DTZ", "E", "EM", "ERA", "F", "FBT", "FLY", "FURB", "G", "I", "ICN", "INP", "INT", "ISC", "LOG", "N", "NPY", "PERF", "PGH", "PIE", "PL", "PT", "PTH", "PYI", "Q", "RET", "RSE", "RUF", "S", "SIM", "SLF", "SLOT", "T10", "T20", "TCH", "TID", "TRY", "UP", "W", "YTT"]
-ignore = ["D203", "D213", "E501", "RET504", "RUF002", "S101", "S307"]
+ignore = ["D203", "D213", "E501", "RET504", "RUF002", "S101", "S307", "TCH004"]
 unfixable = ["ERA001", "F401", "F841", "T201", "T203"]
 
 [tool.ruff.lint.flake8-tidy-imports]

--- a/src/raglite/_chatml_function_calling.py
+++ b/src/raglite/_chatml_function_calling.py
@@ -33,11 +33,14 @@ from typing import (  # noqa: UP035
 
 import jinja2
 from jinja2.sandbox import ImmutableSandboxedEnvironment
-from llama_cpp import llama, llama_grammar, llama_types
-from llama_cpp.llama_chat_format import (
+
+from raglite._lazy_llama import (
     _convert_completion_to_chat,
     _convert_completion_to_chat_function,
     _grammar_for_response_format,
+    llama,
+    llama_grammar,
+    llama_types,
 )
 
 

--- a/src/raglite/_config.py
+++ b/src/raglite/_config.py
@@ -7,9 +7,10 @@ from io import StringIO
 from pathlib import Path
 from typing import Literal
 
-from llama_cpp import llama_supports_gpu_offload
 from platformdirs import user_data_dir
 from sqlalchemy.engine import URL
+
+from raglite._lazy_llama import llama_supports_gpu_offload
 
 # Suppress rerankers output on import until [1] is fixed.
 # [1] https://github.com/AnswerDotAI/rerankers/issues/36

--- a/src/raglite/_embed.py
+++ b/src/raglite/_embed.py
@@ -5,10 +5,10 @@ from typing import Literal
 
 import numpy as np
 from litellm import embedding
-from llama_cpp import LLAMA_POOLING_TYPE_NONE, Llama
 from tqdm.auto import tqdm, trange
 
 from raglite._config import RAGLiteConfig
+from raglite._lazy_llama import LLAMA_POOLING_TYPE_NONE, Llama
 from raglite._litellm import LlamaCppPythonLLM
 from raglite._typing import FloatMatrix, IntVector
 

--- a/src/raglite/_lazy_llama.py
+++ b/src/raglite/_lazy_llama.py
@@ -1,0 +1,93 @@
+"""Import llama_cpp lazily to avoid import errors when it is not installed."""
+
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+# When type checking, import everything normally.
+if TYPE_CHECKING:
+    from llama_cpp import (  # type: ignore[attr-defined]
+        LLAMA_POOLING_TYPE_NONE,
+        Llama,
+        LlamaRAMCache,
+        llama,
+        llama_grammar,
+        llama_supports_gpu_offload,
+        llama_types,
+    )
+    from llama_cpp.llama_chat_format import (
+        _convert_completion_to_chat,
+        _convert_completion_to_chat_function,
+        _grammar_for_response_format,
+    )
+    from llama_cpp.llama_types import (
+        ChatCompletionRequestMessage,
+        ChatCompletionTool,
+        ChatCompletionToolChoiceOption,
+        CreateChatCompletionResponse,
+        CreateChatCompletionStreamResponse,
+    )
+
+# Explicitly export these names for static analysis.
+__all__ = [
+    "llama",
+    "llama_grammar",
+    "llama_types",
+    "Llama",
+    "LLAMA_POOLING_TYPE_NONE",
+    "llama_supports_gpu_offload",
+    "LlamaRAMCache",
+    "_convert_completion_to_chat",
+    "_convert_completion_to_chat_function",
+    "_grammar_for_response_format",
+    "ChatCompletionRequestMessage",
+    "ChatCompletionTool",
+    "ChatCompletionToolChoiceOption",
+    "CreateChatCompletionResponse",
+    "CreateChatCompletionStreamResponse",
+]
+
+
+# Module names for the submodules of llama_cpp.
+LLAMA_CPP_MODULE_NAME = "llama_cpp"
+CHAT_SUBMODULE_NAME = "llama_chat_format"
+TYPES_SUBMODULE_NAME = "llama_types"
+
+# Map attributes that live in submodules to their module names.
+_SUBMODULE_ATTRS = {
+    # Attributes from llama_cpp.llama_chat_format
+    "_convert_completion_to_chat": f"{LLAMA_CPP_MODULE_NAME}.{CHAT_SUBMODULE_NAME}",
+    "_convert_completion_to_chat_function": f"{LLAMA_CPP_MODULE_NAME}.{CHAT_SUBMODULE_NAME}",
+    "_grammar_for_response_format": f"{LLAMA_CPP_MODULE_NAME}.{CHAT_SUBMODULE_NAME}",
+    # Attributes from llama_cpp.llama_types
+    "ChatCompletionRequestMessage": f"{LLAMA_CPP_MODULE_NAME}.{TYPES_SUBMODULE_NAME}",
+    "ChatCompletionTool": f"{LLAMA_CPP_MODULE_NAME}.{TYPES_SUBMODULE_NAME}",
+    "ChatCompletionToolChoiceOption": f"{LLAMA_CPP_MODULE_NAME}.{TYPES_SUBMODULE_NAME}",
+    "CreateChatCompletionResponse": f"{LLAMA_CPP_MODULE_NAME}.{TYPES_SUBMODULE_NAME}",
+    "CreateChatCompletionStreamResponse": f"{LLAMA_CPP_MODULE_NAME}.{TYPES_SUBMODULE_NAME}",
+    # Attributes from the top-level llama_cpp module.
+    "llama": LLAMA_CPP_MODULE_NAME,
+    "llama_grammar": LLAMA_CPP_MODULE_NAME,
+    "llama_types": LLAMA_CPP_MODULE_NAME,
+    "Llama": LLAMA_CPP_MODULE_NAME,
+    "LLAMA_POOLING_TYPE_NONE": LLAMA_CPP_MODULE_NAME,
+}
+
+
+def __getattr__(name: str) -> object:
+    """Import the requested attribute from the llama_cpp module lazily."""
+    module_name = _SUBMODULE_ATTRS.get(name, LLAMA_CPP_MODULE_NAME)
+
+    try:
+        module = import_module(module_name)
+    except ImportError as e:
+        import_error_message = (
+            "llama-cpp-python is required for local language model support.\n"
+            "Install it with `pip install raglite[llama-cpp-python]`."
+        )
+        raise ImportError(import_error_message) from e
+
+    try:
+        return getattr(module, name)
+    except AttributeError as e:
+        attribute_error_message = f"Module '{module_name}' has no attribute '{name}'"
+        raise AttributeError(attribute_error_message) from e

--- a/src/raglite/_litellm.py
+++ b/src/raglite/_litellm.py
@@ -23,7 +23,10 @@ from litellm import (  # type: ignore[attr-defined]
 )
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
 from litellm.utils import custom_llm_setup
-from llama_cpp import (  # type: ignore[attr-defined]
+
+from raglite._chatml_function_calling import chatml_function_calling_with_streaming
+from raglite._config import RAGLiteConfig
+from raglite._lazy_llama import (
     ChatCompletionRequestMessage,
     CreateChatCompletionResponse,
     CreateChatCompletionStreamResponse,
@@ -31,9 +34,6 @@ from llama_cpp import (  # type: ignore[attr-defined]
     LlamaRAMCache,
     llama_supports_gpu_offload,
 )
-
-from raglite._chatml_function_calling import chatml_function_calling_with_streaming
-from raglite._config import RAGLiteConfig
 
 # Reduce the logging level for LiteLLM, flashrank, and httpx.
 litellm.suppress_debug_info = True

--- a/tests/test_chatml_function_calling.py
+++ b/tests/test_chatml_function_calling.py
@@ -5,17 +5,18 @@ from collections.abc import Iterator
 from typing import cast
 
 import pytest
-from llama_cpp import Llama, llama_supports_gpu_offload
-from llama_cpp.llama_types import (
+from typeguard import ForwardRefPolicy, check_type
+
+from raglite._chatml_function_calling import chatml_function_calling_with_streaming
+from raglite._lazy_llama import (
     ChatCompletionRequestMessage,
     ChatCompletionTool,
     ChatCompletionToolChoiceOption,
     CreateChatCompletionResponse,
     CreateChatCompletionStreamResponse,
+    Llama,
+    llama_supports_gpu_offload,
 )
-from typeguard import ForwardRefPolicy, check_type
-
-from raglite._chatml_function_calling import chatml_function_calling_with_streaming
 
 
 def is_accelerator_available() -> bool:


### PR DESCRIPTION
This PR converts `llama-cpp-python` from an installation-time dependency to an optional, runtime, dependency. Previously, installing Raglite involved building a wheel for `llama-cpp-python`, which can fail in some cases, as described in issue #94. It is now possible to install `llama-cpp-python` by running `pip install raglite[llama-cpp-python]`. In the absence of an API-KEY for an API-based LLM provider, Raglite still fails over to `llama-cpp-python` to run locally-hosted LLMs, but now gracefully errors out if `llama-cpp-python` is not installed thanks to a lazy loading of `llama-cpp-python`.

Changes:

- Created of a `_lazy_llama.py` file that lazily loads all. 
- Updated files that required `llama-cpp-python` to leverage the above-mentioned lazy loading mechanism.