### PR TITLE
fix: lazily raise module not found for optional deps

### DIFF
--- a/src/raglite/_chatml_function_calling.py
+++ b/src/raglite/_chatml_function_calling.py
@@ -35,10 +35,8 @@ import jinja2
 from jinja2.sandbox import ImmutableSandboxedEnvironment
 
 from raglite._lazy_llama import (
-    _convert_completion_to_chat,
-    _convert_completion_to_chat_function,
-    _grammar_for_response_format,
     llama,
+    llama_chat_format,
     llama_grammar,
     llama_types,
 )
@@ -150,7 +148,7 @@ def _stream_tool_calls(
             },
         )
         chunks: List[llama_types.CreateCompletionResponse] = []
-        chat_chunks = _convert_completion_to_chat_function(
+        chat_chunks = llama_chat_format._convert_completion_to_chat_function(  # noqa: SLF001
             tool_name,
             _accumulate_chunks(completion_or_chunks, chunks),  # type: ignore[arg-type]
             stream=True,
@@ -340,7 +338,7 @@ def chatml_function_calling_with_streaming(
         grammar
         if grammar is not None
         else (
-            _grammar_for_response_format(response_format)
+            llama_chat_format._grammar_for_response_format(response_format)  # noqa: SLF001
             if response_format is not None and response_format["type"] == "json_object"
             else None
         )
@@ -376,7 +374,7 @@ def chatml_function_calling_with_streaming(
         prompt = template_renderer.render(
             messages=messages, tools=[], tool_calls=None, add_generation_prompt=True
         )
-        return _convert_completion_to_chat(
+        return llama_chat_format._convert_completion_to_chat(  # noqa: SLF001
             llama.create_completion(
                 prompt=prompt,
                 **completion_kwargs,  # type: ignore[arg-type]
@@ -431,7 +429,7 @@ def chatml_function_calling_with_streaming(
         prompt = template_renderer.render(
             messages=messages, tools=[], tool_calls=None, add_generation_prompt=True
         )
-        return _convert_completion_to_chat(
+        return llama_chat_format._convert_completion_to_chat(  # noqa: SLF001
             llama.create_completion(
                 prompt=prompt,
                 **completion_kwargs,  # type: ignore[arg-type]

--- a/src/raglite/_cli.py
+++ b/src/raglite/_cli.py
@@ -48,9 +48,9 @@ def chainlit(ctx: typer.Context) -> None:
     # Import Chainlit here as it's an optional dependency.
     try:
         from chainlit.cli import run_chainlit
-    except ImportError as error:
+    except ModuleNotFoundError as error:
         error_message = "To serve a Chainlit frontend, please install the `chainlit` extra."
-        raise ImportError(error_message) from error
+        raise ModuleNotFoundError(error_message) from error
     # Serve the frontend.
     run_chainlit(__file__.replace("_cli.py", "_chainlit.py"))
 

--- a/src/raglite/_eval.py
+++ b/src/raglite/_eval.py
@@ -225,9 +225,9 @@ def evaluate(
         from raglite._config import RAGLiteConfig
         from raglite._embed import embed_sentences
         from raglite._litellm import LlamaCppPythonLLM
-    except ImportError as import_error:
+    except ModuleNotFoundError as import_error:
         error_message = "To use the `evaluate` function, please install the `ragas` extra."
-        raise ImportError(error_message) from import_error
+        raise ModuleNotFoundError(error_message) from import_error
 
     class RAGLiteRagasEmbeddings(BaseRagasEmbeddings):
         """A RAGLite embedder for Ragas."""

--- a/src/raglite/_litellm.py
+++ b/src/raglite/_litellm.py
@@ -27,12 +27,10 @@ from litellm.utils import custom_llm_setup
 from raglite._chatml_function_calling import chatml_function_calling_with_streaming
 from raglite._config import RAGLiteConfig
 from raglite._lazy_llama import (
-    ChatCompletionRequestMessage,
-    CreateChatCompletionResponse,
-    CreateChatCompletionStreamResponse,
     Llama,
     LlamaRAMCache,
     llama_supports_gpu_offload,
+    llama_types,
 )
 
 # Reduce the logging level for LiteLLM, flashrank, and httpx.
@@ -170,7 +168,7 @@ class LlamaCppPythonLLM(CustomLLM):
     def completion(  # noqa: PLR0913
         self,
         model: str,
-        messages: list[ChatCompletionRequestMessage],
+        messages: list[llama_types.ChatCompletionRequestMessage],
         api_base: str,
         custom_prompt_dict: dict[str, Any],
         model_response: ModelResponse,
@@ -189,7 +187,7 @@ class LlamaCppPythonLLM(CustomLLM):
         llm = self.llm(model)
         llama_cpp_python_params = self._translate_openai_params(optional_params)
         response = cast(
-            "CreateChatCompletionResponse",
+            "llama_types.CreateChatCompletionResponse",
             llm.create_chat_completion(messages=messages, **llama_cpp_python_params),
         )
         litellm_model_response: ModelResponse = convert_to_model_response_object(
@@ -203,7 +201,7 @@ class LlamaCppPythonLLM(CustomLLM):
     def streaming(  # noqa: PLR0913
         self,
         model: str,
-        messages: list[ChatCompletionRequestMessage],
+        messages: list[llama_types.ChatCompletionRequestMessage],
         api_base: str,
         custom_prompt_dict: dict[str, Any],
         model_response: ModelResponse,
@@ -222,7 +220,7 @@ class LlamaCppPythonLLM(CustomLLM):
         llm = self.llm(model)
         llama_cpp_python_params = self._translate_openai_params(optional_params)
         stream = cast(
-            "Iterator[CreateChatCompletionStreamResponse]",
+            "Iterator[llama_types.CreateChatCompletionStreamResponse]",
             llm.create_chat_completion(messages=messages, **llama_cpp_python_params, stream=True),
         )
         for chunk in stream:
@@ -264,7 +262,7 @@ class LlamaCppPythonLLM(CustomLLM):
     async def astreaming(  # type: ignore[misc,override]  # noqa: PLR0913
         self,
         model: str,
-        messages: list[ChatCompletionRequestMessage],
+        messages: list[llama_types.ChatCompletionRequestMessage],
         api_base: str,
         custom_prompt_dict: dict[str, Any],
         model_response: ModelResponse,

--- a/src/raglite/_markdown.py
+++ b/src/raglite/_markdown.py
@@ -208,11 +208,11 @@ def document_to_markdown(doc_path: Path) -> str:
             import pypandoc
 
             doc = pypandoc.convert_file(doc_path, to="gfm")
-        except ImportError as error:
+        except ModuleNotFoundError as error:
             error_message = (
                 "To convert files to Markdown with pandoc, please install the `pandoc` extra."
             )
-            raise ImportError(error_message) from error
+            raise ModuleNotFoundError(error_message) from error
         except RuntimeError:
             # File format not supported, fall back to reading the text.
             doc = doc_path.read_text()

--- a/tests/test_lazy_llama.py
+++ b/tests/test_lazy_llama.py
@@ -1,0 +1,37 @@
+"""Test that llama-cpp-python package is an optional dependency for RAGLite."""
+
+import builtins
+import sys
+from typing import Any
+
+import pytest
+
+
+def test_raglite_import_without_llama_cpp(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that RAGLite can be imported without llama-cpp-python being available."""
+    # Unimport raglite and llama_cpp.
+    module_names = list(sys.modules)
+    for module_name in module_names:
+        if module_name.startswith(("llama_cpp", "raglite", "sqlmodel")):
+            monkeypatch.delitem(sys.modules, module_name, raising=False)
+
+    # Save the original __import__ function.
+    original_import = builtins.__import__
+
+    # Define a fake import function that raises ModuleNotFoundError when trying to import llama_cpp.
+    def fake_import(name: str, *args: Any) -> Any:
+        if name.startswith("llama_cpp"):
+            import_error = f"No module named '{name}'"
+            raise ModuleNotFoundError(import_error)
+        return original_import(name, *args)
+
+    # Monkey patch __import__ with the fake import function.
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    # Verify that importing raglite does not raise an error.
+    import raglite  # noqa: F401
+    from raglite._config import llama_supports_gpu_offload  # type: ignore[attr-defined]
+
+    # Verify that lazily using llama-cpp-python raises a ModuleNotFoundError.
+    with pytest.raises(ModuleNotFoundError, match="llama.cpp models"):
+        llama_supports_gpu_offload()


### PR DESCRIPTION
Changes:
1. Replace `ImportError` with a more specific `ModuleNotFoundError` (which is also an `ImportError`).
2. Lazily raise `ModuleNotFoundError` for attributes and submodules imported from llama-cpp-python (the current behaviour raises that error on import).
3. Add a test to verify that RAGLite can be imported without llama-cpp-python and that it only lazily raises a `ModuleNotFoundError` if you do depend on llama-cpp-python.

CC @rchretien 