### PR TITLE
fix: fix chunking of single-sentence chunks

### DIFF
--- a/src/raglite/_split_chunks.py
+++ b/src/raglite/_split_chunks.py
@@ -68,7 +68,7 @@ def split_chunks(  # noqa: C901, PLR0915
     data = []
     for i in range(len(sentences) - 1):
         r = sentence_length_cumsum[i - 1] if i > 0 else 0
-        idx = np.searchsorted(sentence_length_cumsum - r, max_size + 1)
+        idx = np.searchsorted(sentence_length_cumsum - r, max_size, side="right")
         assert idx > i
         if idx == len(sentence_length_cumsum):
             break

--- a/src/raglite/_split_chunks.py
+++ b/src/raglite/_split_chunks.py
@@ -68,7 +68,7 @@ def split_chunks(  # noqa: C901, PLR0915
     data = []
     for i in range(len(sentences) - 1):
         r = sentence_length_cumsum[i - 1] if i > 0 else 0
-        idx = np.searchsorted(sentence_length_cumsum - r, max_size)
+        idx = np.searchsorted(sentence_length_cumsum - r, max_size + 1)
         assert idx > i
         if idx == len(sentence_length_cumsum):
             break


### PR DESCRIPTION
when a sentence is length max_size (which i guess happens every time there are sentence with length greater than max_size due to max_len in sentence splitter), the chunking fails without clear error on the assert idx > i, since np.searchsorted will return idx = i.

We can use side="right" instead, because we do actually want to find the 'right-most' index as the docs say (because that will yield fewer constraints), and it also solves the off-by-one issue.