### PR TITLE
fix: incorporate headings and prevent windowing chunks

### DIFF
--- a/src/raglite/_insert.py
+++ b/src/raglite/_insert.py
@@ -10,7 +10,7 @@ from tqdm.auto import tqdm
 
 from raglite._config import RAGLiteConfig
 from raglite._database import Chunk, ChunkEmbedding, Document, IndexMetadata, create_database_engine
-from raglite._embed import embed_sentences, sentence_embedding_type
+from raglite._embed import embed_sentences, embed_text, sentence_embedding_type
 from raglite._markdown import document_to_markdown
 from raglite._split_chunks import split_chunks
 from raglite._split_sentences import split_sentences
@@ -46,7 +46,10 @@ def _create_chunk_records(
             )
     else:
         # Embed the full chunks, including the current Markdown headings.
-        full_chunk_embeddings = embed_sentences([str(chunk) for chunk in chunks], config=config)
+        full_chunk_embeddings = embed_text(
+            [str(chunk_record.content) for chunk_record in chunk_records], config=config
+        )
+
         # Every chunk record is associated with a list of chunk embedding records. The chunk
         # embedding records each correspond to a linear combination of a sentence embedding and an
         # embedding of the full chunk with Markdown headings.

--- a/src/raglite/_insert.py
+++ b/src/raglite/_insert.py
@@ -10,7 +10,7 @@ from tqdm.auto import tqdm
 
 from raglite._config import RAGLiteConfig
 from raglite._database import Chunk, ChunkEmbedding, Document, IndexMetadata, create_database_engine
-from raglite._embed import embed_sentences, embed_text, sentence_embedding_type
+from raglite._embed import embed_sentences, embed_strings, sentence_embedding_type
 from raglite._markdown import document_to_markdown
 from raglite._split_chunks import split_chunks
 from raglite._split_sentences import split_sentences
@@ -46,8 +46,8 @@ def _create_chunk_records(
             )
     else:
         # Embed the full chunks, including the current Markdown headings.
-        full_chunk_embeddings = embed_text(
-            [str(chunk_record.content) for chunk_record in chunk_records], config=config
+        full_chunk_embeddings = embed_strings(
+            [chunk_record.content for chunk_record in chunk_records], config=config
         )
 
         # Every chunk record is associated with a list of chunk embedding records. The chunk


### PR DESCRIPTION
Currently, chunks are windowed based on config.embedder_sentence_window_size. This PR refactors _embed and adds an embed_text function we can use for cases where we don't want to accidentally use the embed_sentences functionality, like windowing. It then uses this function in _insert to prevent the windowing of chunks.

Additionally, headings are not incorporated in chunk embeddings. This PR fixes that as well by using the chunk_record.content that has the extracted header, instead of using the input list of chunks