### PR TITLE
feat: add metadata at the document level

### DIFF
--- a/src/raglite/_insert.py
+++ b/src/raglite/_insert.py
@@ -100,6 +100,8 @@ def insert_document(  # noqa: PLR0915
         line of the source is used.
     config
         The RAGLite config to use to insert the document into the database.
+    metadata
+        Document metadata that is attached to the extracted chunks.
 
     Returns
     -------

--- a/src/raglite/_insert.py
+++ b/src/raglite/_insert.py
@@ -98,10 +98,10 @@ def insert_document(  # noqa: PLR0915
     filename
         The document filename to use if the source is a Markdown string. If not provided, the first
         line of the source is used.
-    config
-        The RAGLite config to use to insert the document into the database.
     metadata
         Document metadata that is attached to the extracted chunks.
+    config
+        The RAGLite config to use to insert the document into the database.
 
     Returns
     -------

--- a/src/raglite/_insert.py
+++ b/src/raglite/_insert.py
@@ -21,8 +21,8 @@ def _create_chunk_records(
     document_id: DocumentId,
     chunks: list[str],
     chunk_embeddings: list[FloatMatrix],
-    config: RAGLiteConfig,
     metadata: dict[str, str],
+    config: RAGLiteConfig,
 ) -> tuple[list[Chunk], list[list[ChunkEmbedding]]]:
     """Process chunks into chunk and chunk embedding records."""
     # Create the chunk records.
@@ -86,8 +86,8 @@ def insert_document(  # noqa: PLR0915
     source: Path | str,
     *,
     filename: str | None = None,
-    config: RAGLiteConfig | None = None,
     metadata: dict[str, str] | None = None,
+    config: RAGLiteConfig | None = None,
 ) -> None:
     """Insert a document into the database and update the index.
 
@@ -109,8 +109,6 @@ def insert_document(  # noqa: PLR0915
     """
     # Use the default config if not provided.
     config = config or RAGLiteConfig()
-    if metadata is None:
-        metadata = {}
     # Preprocess the document into chunks and chunk embeddings.
     with tqdm(total=6, unit="step", dynamic_ncols=True) as pbar:
         pbar.set_description("Initializing database")
@@ -149,7 +147,7 @@ def insert_document(  # noqa: PLR0915
             session.add(document_record)
             for chunk_record, chunk_embedding_record_list in zip(
                 *_create_chunk_records(
-                    document_record.id, chunks, chunk_embeddings, config, metadata=metadata
+                    document_record.id, chunks, chunk_embeddings, metadata or {}, config
                 ),
                 strict=True,
             ):


### PR DESCRIPTION
Adds a argument in insert_document of metadata that gets passed to all chunks built from the file