### PR TITLE
feat: introduce chunklets to improve chunking

### DIFF
--- a/src/raglite/_config.py
+++ b/src/raglite/_config.py
@@ -46,7 +46,6 @@ class RAGLiteConfig:
         )
     )
     embedder_normalize: bool = True
-    embedder_sentence_window_size: int = 3
     # Chunk config used to partition documents into chunks.
     chunk_max_size: int = 1440  # Max number of characters per chunk.
     # Vector search config.
@@ -61,8 +60,3 @@ class RAGLiteConfig:
         ),
         compare=False,  # Exclude the reranker from comparison to avoid lru_cache misses.
     )
-
-    def __post_init__(self) -> None:
-        # Late chunking with llama-cpp-python does not apply sentence windowing.
-        if self.embedder.startswith("llama-cpp-python"):
-            object.__setattr__(self, "embedder_sentence_window_size", 1)

--- a/src/raglite/_eval.py
+++ b/src/raglite/_eval.py
@@ -223,7 +223,7 @@ def evaluate(
         from ragas.embeddings import BaseRagasEmbeddings
 
         from raglite._config import RAGLiteConfig
-        from raglite._embed import embed_sentences
+        from raglite._embed import embed_strings
         from raglite._litellm import LlamaCppPythonLLM
     except ModuleNotFoundError as import_error:
         error_message = "To use the `evaluate` function, please install the `ragas` extra."
@@ -237,12 +237,12 @@ def evaluate(
 
         def embed_query(self, text: str) -> list[float]:
             # Embed the input text with RAGLite's embedding function.
-            embeddings = embed_sentences([text], config=self.config)
+            embeddings = embed_strings([text], config=self.config)
             return embeddings[0].tolist()  # type: ignore[no-any-return]
 
         def embed_documents(self, texts: list[str]) -> list[list[float]]:
             # Embed a list of documents with RAGLite's embedding function.
-            embeddings = embed_sentences(texts, config=self.config)
+            embeddings = embed_strings(texts, config=self.config)
             return embeddings.tolist()  # type: ignore[no-any-return]
 
     # Create a set of answered evals if not provided.

--- a/src/raglite/_insert.py
+++ b/src/raglite/_insert.py
@@ -10,8 +10,9 @@ from tqdm.auto import tqdm
 
 from raglite._config import RAGLiteConfig
 from raglite._database import Chunk, ChunkEmbedding, Document, IndexMetadata, create_database_engine
-from raglite._embed import embed_sentences, embed_strings, sentence_embedding_type
+from raglite._embed import embed_strings, embed_strings_without_late_chunking, embedding_type
 from raglite._markdown import document_to_markdown
+from raglite._split_chunklets import split_chunklets
 from raglite._split_chunks import split_chunks
 from raglite._split_sentences import split_sentences
 from raglite._typing import DocumentId, FloatMatrix
@@ -34,24 +35,23 @@ def _create_chunk_records(
         headings = record.extract_headings()
     # Create the chunk embedding records.
     chunk_embedding_records = []
-    if sentence_embedding_type(config=config) == "late_chunking":
+    if embedding_type(config=config) == "late_chunking":
         # Every chunk record is associated with a list of chunk embedding records, one for each of
-        # the sentences in the chunk.
+        # the chunklets in the chunk.
         for chunk_record, chunk_embedding in zip(chunk_records, chunk_embeddings, strict=True):
             chunk_embedding_records.append(
                 [
-                    ChunkEmbedding(chunk_id=chunk_record.id, embedding=sentence_embedding)
-                    for sentence_embedding in chunk_embedding
+                    ChunkEmbedding(chunk_id=chunk_record.id, embedding=chunklet_embedding)
+                    for chunklet_embedding in chunk_embedding
                 ]
             )
     else:
         # Embed the full chunks, including the current Markdown headings.
-        full_chunk_embeddings = embed_strings(
+        full_chunk_embeddings = embed_strings_without_late_chunking(
             [chunk_record.content for chunk_record in chunk_records], config=config
         )
-
         # Every chunk record is associated with a list of chunk embedding records. The chunk
-        # embedding records each correspond to a linear combination of a sentence embedding and an
+        # embedding records each correspond to a linear combination of a chunklet embedding and an
         # embedding of the full chunk with Markdown headings.
         α = 0.382  # Golden ratio.  # noqa: PLC2401
         for chunk_record, chunk_embedding, full_chunk_embedding in zip(
@@ -62,9 +62,9 @@ def _create_chunk_records(
                     [
                         ChunkEmbedding(
                             chunk_id=chunk_record.id,
-                            embedding=α * sentence_embedding + (1 - α) * full_chunk_embedding,
+                            embedding=α * chunklet_embedding + (1 - α) * full_chunk_embedding,
                         )
-                        for sentence_embedding in chunk_embedding
+                        for chunklet_embedding in chunk_embedding
                     ]
                 )
             else:
@@ -103,9 +103,9 @@ def insert_document(  # noqa: PLR0915
     """
     # Use the default config if not provided.
     config = config or RAGLiteConfig()
-
     # Preprocess the document into chunks and chunk embeddings.
-    with tqdm(total=6, unit="step", dynamic_ncols=True) as pbar:
+    total_steps = 7
+    with tqdm(total=total_steps, unit="step", dynamic_ncols=True) as pbar:
         pbar.set_description("Initializing database")
         engine = create_database_engine(config)
         pbar.update(1)
@@ -119,21 +119,23 @@ def insert_document(  # noqa: PLR0915
         with Session(engine) as session:  # Exit early if the document is already in the database.
             if session.get(Document, document_record.id) is not None:
                 pbar.set_description("Document already in database")
-                pbar.update(5)
+                pbar.update(total_steps - 1)
                 pbar.close()
                 return
         pbar.update(1)
         pbar.set_description("Splitting sentences")
         sentences = split_sentences(doc, max_len=config.chunk_max_size)
         pbar.update(1)
-        pbar.set_description("Embedding sentences")
-        sentence_embeddings = embed_sentences(sentences, config=config)
+        pbar.set_description("Splitting chunklets")
+        chunklets = split_chunklets(sentences, max_size=config.chunk_max_size)
+        pbar.update(1)
+        pbar.set_description("Embedding chunklets")
+        chunklet_embeddings = embed_strings(chunklets, config=config)
         pbar.update(1)
         pbar.set_description("Splitting chunks")
         chunks, chunk_embeddings = split_chunks(
-            sentences=sentences,
-            sentence_embeddings=sentence_embeddings,
-            sentence_window_size=config.embedder_sentence_window_size,
+            chunklets=chunklets,
+            chunklet_embeddings=chunklet_embeddings,
             max_size=config.chunk_max_size,
         )
         pbar.update(1)

--- a/src/raglite/_litellm.py
+++ b/src/raglite/_litellm.py
@@ -349,13 +349,13 @@ def get_embedding_dim(config: RAGLiteConfig, *, fallback: bool = True) -> int:
         return embedding_dim
     # If that fails, fall back to embedding a single sentence and reading its embedding dimension.
     if fallback:
-        from raglite._embed import embed_sentences
+        from raglite._embed import embed_strings
 
         warnings.warn(
             f"Could not determine the embedding dimension of {config.embedder} from LiteLLM's model_info, using fallback.",
             stacklevel=2,
         )
-        fallback_embeddings = embed_sentences(["Hello world"], config=config)
+        fallback_embeddings = embed_strings(["Hello world"], config=config)
         return fallback_embeddings.shape[1]
     error_message = f"Could not determine the embedding dimension of {config.embedder}."
     raise ValueError(error_message)

--- a/src/raglite/_query_adapter.py
+++ b/src/raglite/_query_adapter.py
@@ -7,7 +7,7 @@ from tqdm.auto import tqdm
 
 from raglite._config import RAGLiteConfig
 from raglite._database import Chunk, ChunkEmbedding, Eval, IndexMetadata, create_database_engine
-from raglite._embed import embed_sentences
+from raglite._embed import embed_strings
 from raglite._search import vector_search
 
 
@@ -88,7 +88,7 @@ def update_query_adapter(  # noqa: PLR0915, C901
             evals, desc="Extracting triplets from evals", unit="eval", dynamic_ncols=True
         ):
             # Embed the question.
-            question_embedding = embed_sentences([eval_.question], config=config)
+            question_embedding = embed_strings([eval_.question], config=config)
             # Retrieve chunks that would be used to answer the question.
             chunk_ids, _ = vector_search(
                 question_embedding, num_results=optimize_top_k, config=config_no_query_adapter

--- a/src/raglite/_search.py
+++ b/src/raglite/_search.py
@@ -21,7 +21,7 @@ from raglite._database import (
     IndexMetadata,
     create_database_engine,
 )
-from raglite._embed import embed_sentences
+from raglite._embed import embed_strings
 from raglite._typing import ChunkId, FloatMatrix
 
 
@@ -40,7 +40,7 @@ def vector_search(
     index_metadata = IndexMetadata.get("default", config=config)
     # Embed the query.
     query_embedding = (
-        embed_sentences([query], config=config)[0, :] if isinstance(query, str) else np.ravel(query)
+        embed_strings([query], config=config)[0, :] if isinstance(query, str) else np.ravel(query)
     )
     # Apply the query adapter to the query embedding.
     Q = index_metadata.get("query_adapter")  # noqa: N806

--- a/src/raglite/_split_chunklets.py
+++ b/src/raglite/_split_chunklets.py
@@ -1,0 +1,115 @@
+"""Split a document into chunklets."""
+
+from collections.abc import Callable
+
+import numpy as np
+from markdown_it import MarkdownIt
+
+from raglite._typing import FloatVector
+
+
+def markdown_chunklet_boundaries(sentences: list[str]) -> FloatVector:
+    """Estimate chunklet boundary probabilities given a Markdown document."""
+    # Parse the document.
+    doc = "".join(sentences)
+    md = MarkdownIt()
+    tokens = md.parse(doc)
+    # Identify the character index of each line in the document.
+    lines = doc.splitlines(keepends=True)
+    line_start_char = [0]
+    for line in lines[:-1]:
+        line_start_char.append(line_start_char[-1] + len(line))
+    # Identify the character index of each sentence in the document.
+    sentence_start_char = [0]
+    for sentence in sentences[:-1]:
+        sentence_start_char.append(sentence_start_char[-1] + len(sentence))
+    # Map each line index to a corresponding sentence index.
+    line_to_sentence = np.searchsorted(sentence_start_char, line_start_char, side="right") - 1
+    # Configure probabilities for token types to be chunklet boundaries.
+    token_type_to_proba = {
+        "blockquote_open": 0.75,
+        "bullet_list_open": 0.25,
+        "heading_open": 1.0,
+        "paragraph_open": 0.5,
+        "ordered_list_open": 0.25,
+    }
+    # Compute the boundary probabilities for each sentence.
+    last_sentence = -1
+    boundary_probas = np.zeros(len(sentences))
+    for token in tokens:
+        if token.type in token_type_to_proba:
+            start_line, _ = token.map  # type: ignore[misc]
+            if (i := line_to_sentence[start_line]) != last_sentence:
+                boundary_probas[i] = token_type_to_proba[token.type]
+                last_sentence = i  # type: ignore[assignment]
+    # For segments of consecutive boundaries, encourage splitting on the largest boundary in the
+    # segment by setting the other boundary probabilities in the segment to zero.
+    mask = boundary_probas != 0.0
+    split_indices = np.flatnonzero(mask[1:] != mask[:-1]) + 1
+    segments = np.split(boundary_probas, split_indices)
+    for segment in segments:
+        max_idx, max_proba = np.argmax(segment), np.max(segment)
+        segment[:] = 0.0
+        segment[max_idx] = max_proba
+    boundary_probas = np.concatenate(segments)
+    return boundary_probas
+
+
+def compute_num_statements(sentences: list[str]) -> FloatVector:
+    """Compute the approximate number of statements of each sentence in a list of sentences."""
+    sentence_word_length = np.asarray(
+        [len(sentence.split()) for sentence in sentences], dtype=np.float64
+    )
+    q25, q75 = np.quantile(sentence_word_length, [0.25, 0.75])
+    num_statements = np.piecewise(
+        sentence_word_length,
+        [sentence_word_length < q25, sentence_word_length >= q25],
+        [lambda n: 0.75 * n / q25, lambda n: 0.75 + 0.5 * (n - q25) / (q75 - q25)],
+    )
+    return num_statements
+
+
+def split_chunklets(
+    sentences: list[str],
+    boundary_cost: Callable[[FloatVector], float] = lambda p: (1.0 - p[0]) + np.sum(p[1:]),
+    statement_cost: Callable[[float], float] = lambda s: ((s - 3) ** 2 / np.sqrt(max(s, 1e-6) / 2)),
+    max_size: int = 1440,
+) -> list[str]:
+    """Split document sentences into optimal chunklets."""
+    # Precompute chunklet boundary probabilities and each sentence's number of statements.
+    boundary_probas = markdown_chunklet_boundaries(sentences)
+    num_statements = compute_num_statements(sentences)
+    # Initialize a dynamic programming table and backpointers. The dynamic programming table dp[i]
+    # is defined as the minimum cost to segment the first i sentences (i.e., sentences[:i]).
+    num_sentences = len(sentences)
+    dp = np.full(num_sentences + 1, np.inf)
+    dp[0] = 0.0
+    back = -np.ones(num_sentences + 1, dtype=np.intp)
+    # Compute the cost of partitioning sentences into chunklets.
+    for i in range(1, num_sentences + 1):
+        for j in range(i):
+            # Limit the chunklets to a maximum size.
+            if sum(len(s) for s in sentences[j:i]) > max_size:
+                continue
+            # Compute the cost of partitioning sentences[j:i] into a single chunklet.
+            cost_ji = boundary_cost(boundary_probas[j:i])
+            cost_ji += statement_cost(np.sum(num_statements[j:i]))
+            # Compute the cost of partitioning sentences[:i] if we were to split at j.
+            cost_0i = dp[j] + cost_ji
+            # If the cost is less than the current minimum, update the DP table and backpointer.
+            if cost_0i < dp[i]:
+                dp[i] = cost_0i
+                back[i] = j
+    # Recover the optimal partitioning.
+    partition_indices: list[int] = []
+    i = back[num_sentences]
+    while i > 0:
+        partition_indices.append(i)
+        i = back[i]
+    partition_indices.reverse()
+    # Split the sentences into optimal chunklets.
+    chunklets = [
+        "".join(sentences[i:j])
+        for i, j in zip([0, *partition_indices], [*partition_indices, len(sentences)], strict=True)
+    ]
+    return chunklets

--- a/src/raglite/_split_chunks.py
+++ b/src/raglite/_split_chunks.py
@@ -9,68 +9,62 @@ from scipy.sparse import coo_matrix
 from raglite._typing import FloatMatrix
 
 
-def split_chunks(  # noqa: C901, PLR0915
-    sentences: list[str],
-    sentence_embeddings: FloatMatrix,
-    sentence_window_size: int = 3,
+def split_chunks(  # noqa: C901
+    chunklets: list[str],
+    chunklet_embeddings: FloatMatrix,
     max_size: int = 1440,
 ) -> tuple[list[str], list[FloatMatrix]]:
-    """Split sentences into optimal semantic chunks with corresponding sentence embeddings."""
+    """Split chunklets into optimal semantic chunks with corresponding chunklet embeddings."""
     # Validate the input.
-    sentence_length = np.asarray([len(sentence) for sentence in sentences])
-    if not np.all(sentence_length <= max_size):
-        error_message = "Sentence with length larger than chunk max_size detected."
+    chunklet_size = np.asarray([len(chunklet) for chunklet in chunklets])
+    if not np.all(chunklet_size <= max_size):
+        error_message = "Chunklet larger than chunk max_size detected."
         raise ValueError(error_message)
-    if not np.all(np.linalg.norm(sentence_embeddings, axis=1) > 0.0):
-        error_message = "Sentence embeddings with zero norm detected."
+    if not np.all(np.linalg.norm(chunklet_embeddings, axis=1) > 0.0):
+        error_message = "Chunklet embeddings with zero norm detected."
         raise ValueError(error_message)
     # Exit early if there is only one chunk to return.
-    if len(sentences) <= 1 or sum(sentence_length) <= max_size:
-        return ["".join(sentences)] if sentences else sentences, [sentence_embeddings]
-    # Normalise the sentence embeddings to unit norm.
-    X = sentence_embeddings.astype(np.float32)  # noqa: N806
+    if len(chunklets) <= 1 or sum(chunklet_size) <= max_size:
+        return ["".join(chunklets)] if chunklets else chunklets, [chunklet_embeddings]
+    # Normalise the chunklet embeddings to unit norm.
+    X = chunklet_embeddings.astype(np.float32)  # noqa: N806
     X = X / np.linalg.norm(X, axis=1, keepdims=True)  # noqa: N806
-    # Select nonoutlying sentences and remove the discourse vector.
-    q15, q85 = np.quantile(sentence_length, [0.15, 0.85])
-    nonoutlying_sentences = (q15 <= sentence_length) & (sentence_length <= q85)
-    discourse = np.mean(X[nonoutlying_sentences, :], axis=0)
+    # Select nonoutlying chunklets and remove the discourse vector.
+    q15, q85 = np.quantile(chunklet_size, [0.15, 0.85])
+    nonoutlying_chunklets = (q15 <= chunklet_size) & (chunklet_size <= q85)
+    discourse = np.mean(X[nonoutlying_chunklets, :], axis=0)
     discourse = discourse / np.linalg.norm(discourse)
     if not np.any(np.linalg.norm(X - discourse[np.newaxis, :], axis=1) <= np.finfo(X.dtype).eps):
         X = X - np.outer(X @ discourse, discourse)  # noqa: N806
         X = X / np.linalg.norm(X, axis=1, keepdims=True)  # noqa: N806
-    # For each partition point in the list of sentences, compute the similarity of the windows
-    # before and after the partition point. Sentence embeddings are assumed to be of the sentence
-    # itself and at most the (sentence_window_size - 1) sentences that preceed it.
-    sentence_window_size = min(len(sentences) - 1, sentence_window_size)
-    windows_before = X[:-sentence_window_size]
-    windows_after = X[sentence_window_size:]
-    partition_similarity = np.ones(len(sentences) - 1, dtype=X.dtype)
-    partition_similarity[: len(windows_before)] = np.sum(windows_before * windows_after, axis=1)
+    # For each partition point in the list of chunklets, compute the similarity of chunklet before
+    # and after the partition point.
+    partition_similarity = np.sum(X[:-1] * X[1:], axis=1)
     # Make partition similarity nonnegative before modification and optimisation.
     partition_similarity = np.maximum(
         (partition_similarity + 1) / 2, np.sqrt(np.finfo(X.dtype).eps)
     )
     # Modify the partition similarity to encourage splitting on Markdown headings.
-    prev_sentence_is_heading = True
-    for i, sentence in enumerate(sentences[:-1]):
-        is_heading = bool(re.match(r"^#+\s", sentence.replace("\n", "").strip()))
+    prev_chunklet_is_heading = True
+    for i, chunklet in enumerate(chunklets[:-1]):
+        is_heading = bool(re.match(r"^#+\s", chunklet.replace("\n", "").strip()))
         if is_heading:
             # Encourage splitting before a heading.
-            if not prev_sentence_is_heading:
+            if not prev_chunklet_is_heading:
                 partition_similarity[i - 1] = partition_similarity[i - 1] / 4
             # Don't split immediately after a heading.
             partition_similarity[i] = 1.0
-        prev_sentence_is_heading = is_heading
+        prev_chunklet_is_heading = is_heading
     # Solve an optimisation problem to find the best partition points.
-    sentence_length_cumsum = np.cumsum(sentence_length)
+    chunklet_size_cumsum = np.cumsum(chunklet_size)
     row_indices = []
     col_indices = []
     data = []
-    for i in range(len(sentences) - 1):
-        r = sentence_length_cumsum[i - 1] if i > 0 else 0
-        idx = np.searchsorted(sentence_length_cumsum - r, max_size, side="right")
+    for i in range(len(chunklets) - 1):
+        r = chunklet_size_cumsum[i - 1] if i > 0 else 0
+        idx = np.searchsorted(chunklet_size_cumsum - r, max_size, side="right")
         assert idx > i
-        if idx == len(sentence_length_cumsum):
+        if idx == len(chunklet_size_cumsum):
             break
         cols = list(range(i, idx))
         col_indices.extend(cols)
@@ -78,7 +72,7 @@ def split_chunks(  # noqa: C901, PLR0915
         data.extend([1] * len(cols))
     A = coo_matrix(  # noqa: N806
         (data, (row_indices, col_indices)),
-        shape=(max(row_indices) + 1, len(sentences) - 1),
+        shape=(max(row_indices) + 1, len(chunklets) - 1),
         dtype=np.float32,
     )
     b_ub = np.ones(A.shape[0], dtype=np.float32)
@@ -92,11 +86,11 @@ def split_chunks(  # noqa: C901, PLR0915
     if not res.success:
         error_message = "Optimization of chunk partitions failed."
         raise ValueError(error_message)
-    # Split the sentences and their window embeddings into optimal chunks.
+    # Split the chunklets and their window embeddings into optimal chunks.
     partition_indices = (np.where(res.x)[0] + 1).tolist()
     chunks = [
-        "".join(sentences[i:j])
-        for i, j in zip([0, *partition_indices], [*partition_indices, len(sentences)], strict=True)
+        "".join(chunklets[i:j])
+        for i, j in zip([0, *partition_indices], [*partition_indices, len(chunklets)], strict=True)
     ]
-    chunk_embeddings = np.split(sentence_embeddings, partition_indices)
+    chunk_embeddings = np.split(chunklet_embeddings, partition_indices)
     return chunks, chunk_embeddings

--- a/src/raglite/_split_sentences.py
+++ b/src/raglite/_split_sentences.py
@@ -31,14 +31,14 @@ def markdown_sentence_boundaries(doc: str) -> FloatVector:
         tokens = md.parse(doc)
         headings = []
         lines = doc.splitlines(keepends=True)
-        char_idx = [0]
-        for line in lines:
-            char_idx.append(char_idx[-1] + len(line))
+        line_start_char = [0]
+        for line in lines[:-1]:
+            line_start_char.append(line_start_char[-1] + len(line))
         for token in tokens:
             if token.type == "heading_open":
                 start_line, end_line = token.map  # type: ignore[misc]
-                heading_start = char_idx[start_line]
-                heading_end = char_idx[end_line]
+                heading_start = line_start_char[start_line]
+                heading_end = line_start_char[end_line]
                 headings.append((heading_start, heading_end + 1))
         return headings
 

--- a/tests/test_embed.py
+++ b/tests/test_embed.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import numpy as np
 
 from raglite import RAGLiteConfig
-from raglite._embed import embed_sentences
+from raglite._embed import embed_strings
 from raglite._markdown import document_to_markdown
 from raglite._split_sentences import split_sentences
 
@@ -16,7 +16,7 @@ def test_embed(embedder: str) -> None:
     doc_path = Path(__file__).parent / "specrel.pdf"  # Einstein's special relativity paper.
     doc = document_to_markdown(doc_path)
     sentences = split_sentences(doc, max_len=raglite_test_config.chunk_max_size)
-    sentence_embeddings = embed_sentences(sentences, config=raglite_test_config)
+    sentence_embeddings = embed_strings(sentences, config=raglite_test_config)
     assert isinstance(sentences, list)
     assert isinstance(sentence_embeddings, np.ndarray)
     assert len(sentences) == len(sentence_embeddings)

--- a/tests/test_split_chunklets.py
+++ b/tests/test_split_chunklets.py
@@ -1,0 +1,88 @@
+"""Test RAGLite's chunk splitting functionality."""
+
+import pytest
+
+from raglite._split_chunklets import split_chunklets
+
+
+@pytest.mark.parametrize(
+    "sentences_splits",
+    [
+        pytest.param(
+            (
+                [
+                    # Sentence 1:
+                    "It is known that Maxwell’s electrodynamics—as usually understood at the\n"  # noqa: RUF001
+                    "present time—when applied to moving bodies, leads to asymmetries which do\n\n"
+                    "not appear to be inherent in the phenomena. ",
+                    # Sentence 2:
+                    "Take, for example, the recipro-\ncal electrodynamic action of a magnet and a conductor. \n\n",
+                    # Sentence 3 (heading):
+                    "# ON THE ELECTRODYNAMICS OF MOVING BODIES\n\n",
+                    # Sentence 4 (heading):
+                    "## By A. EINSTEIN June 30, 1905\n\n",
+                    # Sentence 5 (paragraph boundary):
+                    "The observable phe-\n"
+                    "nomenon here depends only on the relative motion of the conductor and the\n"
+                    "magnet, whereas the customary view draws a sharp distinction between the two\n"
+                    "cases in which either the one or the other of these bodies is in motion. ",
+                    # Sentence 6:
+                    "For if the\n"
+                    "magnet is in motion and the conductor at rest, there arises in the neighbour-\n"
+                    "hood of the magnet an electric field with a certain definite energy, producing\n"
+                    "a current at the places where parts of the conductor are situated. ",
+                ],
+                [2],
+            ),
+            id="consecutive_boundaries",
+        ),
+        pytest.param(
+            (
+                [
+                    # Sentence 1:
+                    "The theory to be developed is based—like all electrodynamics—on the kine-\n"
+                    "matics of the rigid body, since the assertions of any such theory have to do\n"
+                    "with the relationships between rigid bodies (systems of co-ordinates), clocks,\n"
+                    "and electromagnetic processes. ",
+                    # Sentence 2:
+                    "Insufficient consideration of this circumstance\n"
+                    "lies at the root of the difficulties which the electrodynamics of moving bodies\n"
+                    "at present encounters.\n\n",
+                    # Sentence 3 (paragraph boundary):
+                    "The observable phe-\n"
+                    "nomenon here depends only on the relative motion of the conductor and the\n"
+                    "magnet, whereas the customary view draws a sharp distinction between the two\n"
+                    "cases in which either the one or the other of these bodies is in motion. ",
+                    # Sentence 4:
+                    "For if the\n"
+                    "magnet is in motion and the conductor at rest, there arises in the neighbour-\n"
+                    "hood of the magnet an electric field with a certain definite energy, producing\n"
+                    "a current at the places where parts of the conductor are situated. ",
+                    # Sentence 5:
+                    "But if the\n"
+                    "magnet is stationary and the conductor in motion, no electric field arises in the\n"
+                    "neighbourhood of the magnet. ",
+                ],
+                [2],
+            ),
+            id="paragraph_boundary",
+        ),
+    ],
+)
+def test_split_chunklets(sentences_splits: tuple[list[str], list[int]]) -> None:
+    """Test chunklet splitting."""
+    sentences, splits = sentences_splits
+    chunklets = split_chunklets(sentences)
+    expected_chunklets = [
+        "".join(sentences[i:j])
+        for i, j in zip([0, *splits], [*splits, len(sentences)], strict=True)
+    ]
+    assert isinstance(chunklets, list)
+    assert all(isinstance(chunklet, str) for chunklet in chunklets)
+    assert sum(len(chunklet) for chunklet in chunklets) == sum(
+        len(sentence) for sentence in sentences
+    )
+    assert all(
+        chunklet == expected_chunklet
+        for chunklet, expected_chunklet in zip(chunklets, expected_chunklets, strict=True)
+    )

--- a/tests/test_split_chunks.py
+++ b/tests/test_split_chunks.py
@@ -7,50 +7,46 @@ from raglite._split_chunks import split_chunks
 
 
 @pytest.mark.parametrize(
-    "sentences",
+    "chunklets",
     [
-        pytest.param([], id="one_chunk:no_sentences"),
-        pytest.param(["Hello world"], id="one_chunk:one_sentence"),
-        pytest.param(["Hello world"] * 2, id="one_chunk:two_sentences"),
-        pytest.param(["Hello world"] * 3, id="one_chunk:three_sentences"),
-        pytest.param(["Hello world"] * 100, id="one_chunk:many_sentences"),
-        pytest.param(["Hello world", "X" * 1000], id="n_chunks:two_sentences_a"),
-        pytest.param(["X" * 1000, "Hello world"], id="n_chunks:two_sentences_b"),
-        pytest.param(["Hello world", "X" * 1000, "X" * 1000], id="n_chunks:three_sentences_a"),
-        pytest.param(["X" * 1000, "Hello world", "X" * 1000], id="n_chunks:three_sentences_b"),
-        pytest.param(["X" * 1000, "X" * 1000, "Hello world"], id="n_chunks:three_sentences_c"),
-        pytest.param(["X" * 1000] * 100, id="n_chunks:many_sentences_a"),
-        pytest.param(["X" * 100] * 1000, id="n_chunks:many_sentences_b"),
+        pytest.param([], id="one_chunk:no_chunklets"),
+        pytest.param(["Hello world"], id="one_chunk:one_chunklet"),
+        pytest.param(["Hello world"] * 2, id="one_chunk:two_chunklets"),
+        pytest.param(["Hello world"] * 3, id="one_chunk:three_chunklets"),
+        pytest.param(["Hello world"] * 100, id="one_chunk:many_chunklets"),
+        pytest.param(["Hello world", "X" * 1000], id="n_chunks:two_chunklets_a"),
+        pytest.param(["X" * 1000, "Hello world"], id="n_chunks:two_chunklets_b"),
+        pytest.param(["Hello world", "X" * 1000, "X" * 1000], id="n_chunks:three_chunklets_a"),
+        pytest.param(["X" * 1000, "Hello world", "X" * 1000], id="n_chunks:three_chunklets_b"),
+        pytest.param(["X" * 1000, "X" * 1000, "Hello world"], id="n_chunks:three_chunklets_c"),
+        pytest.param(["X" * 1000] * 100, id="n_chunks:many_chunklets_a"),
+        pytest.param(["X" * 100] * 1000, id="n_chunks:many_chunklets_b"),
     ],
 )
-def test_edge_cases(sentences: list[str]) -> None:
+def test_edge_cases(chunklets: list[str]) -> None:
     """Test chunk splitting edge cases."""
-    sentence_embeddings = np.ones((len(sentences), 768)).astype(np.float16)
-    chunks, chunk_embeddings = split_chunks(
-        sentences, sentence_embeddings, sentence_window_size=3, max_size=1440
-    )
+    chunklet_embeddings = np.ones((len(chunklets), 768)).astype(np.float16)
+    chunks, chunk_embeddings = split_chunks(chunklets, chunklet_embeddings, max_size=1440)
     assert isinstance(chunks, list)
     assert isinstance(chunk_embeddings, list)
-    assert len(chunk_embeddings) == (len(chunks) if sentences else 1)
+    assert len(chunk_embeddings) == (len(chunks) if chunklets else 1)
     assert all(isinstance(chunk, str) for chunk in chunks)
     assert all(isinstance(chunk_embedding, np.ndarray) for chunk_embedding in chunk_embeddings)
-    assert all(ce.dtype == sentence_embeddings.dtype for ce in chunk_embeddings)
-    assert sum(ce.shape[0] for ce in chunk_embeddings) == sentence_embeddings.shape[0]
-    assert all(ce.shape[1] == sentence_embeddings.shape[1] for ce in chunk_embeddings)
+    assert all(ce.dtype == chunklet_embeddings.dtype for ce in chunk_embeddings)
+    assert sum(ce.shape[0] for ce in chunk_embeddings) == chunklet_embeddings.shape[0]
+    assert all(ce.shape[1] == chunklet_embeddings.shape[1] for ce in chunk_embeddings)
 
 
 @pytest.mark.parametrize(
-    "sentences",
+    "chunklets",
     [
         pytest.param(["Hello world" * 1000] + ["X"] * 100, id="first"),
         pytest.param(["X"] * 50 + ["Hello world" * 1000] + ["X"] * 50, id="middle"),
         pytest.param(["X"] * 100 + ["Hello world" * 1000], id="last"),
     ],
 )
-def test_long_sentence(sentences: list[str]) -> None:
-    """Test chunking on sentences that are too long."""
-    sentence_embeddings = np.ones((len(sentences), 768)).astype(np.float16)
-    with pytest.raises(
-        ValueError, match="Sentence with length larger than chunk max_size detected."
-    ):
-        _ = split_chunks(sentences, sentence_embeddings, sentence_window_size=3, max_size=1440)
+def test_long_chunklet(chunklets: list[str]) -> None:
+    """Test chunking on chunklets that are too long."""
+    chunklet_embeddings = np.ones((len(chunklets), 768)).astype(np.float16)
+    with pytest.raises(ValueError, match="Chunklet larger than chunk max_size detected."):
+        _ = split_chunks(chunklets, chunklet_embeddings, max_size=1440)


### PR DESCRIPTION
This PR introduces a new level between sentences and chunks called 'chunklets'. A chunklet can be thought of as approximately 3 'statements', where we define a statement is defined as a median-length sentence.

Changes:
1. 🥇 Compute optimal chunklets with dynamic programming. Optimal means the chunklet contains as close to 3 statements (not too few and not too many) as it can, and tries to align as well as it can with Markdown section boundaries such as headers, paragraphs and item lists.
2. 🍫 Optimal chunks are no longer optimized based on sentence window similarity, but chunklet similarity. This simplifies the implementation as we no longer need windowing logic.
3. 🔎 Multi-vector retrieval is no longer based on sentence embeddings but on chunklet embeddings. Because chunklets are slightly larger than sentences, this should help improve retrieval quality.
4. ❌ Remove `RAGLiteConfig.embedder_sentence_window_size`.
5. ✍️ Rename `_embed.embed_sentences` to `_embed.embed_strings`, which now dynamically calls `embed_strings_with_late_chunking` or `embed_strings_without_late_chunking` depending on the selected embedding model.