### PR TITLE
feat: add support for reasoning tool use and upgrade to Qwen3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,8 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: raglite
 
     strategy:
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ RAGLite is a Python toolkit for Retrieval-Augmented Generation (RAG) with Postgr
 > 🚀 If you want to use local models, it is recommended to install [an accelerated llama-cpp-python precompiled binary](https://github.com/abetlen/llama-cpp-python?tab=readme-ov-file#supported-backends) with:
 > ```sh
 > # Configure which llama-cpp-python precompiled binary to install (⚠️ not every combination is available):
-> LLAMA_CPP_PYTHON_VERSION=0.3.4
+> LLAMA_CPP_PYTHON_VERSION=0.3.9
 > PYTHON_VERSION=310|311|312
 > ACCELERATOR=metal|cu121|cu122|cu123|cu124
 > PLATFORM=macosx_11_0_arm64|linux_x86_64|win_amd64
@@ -92,7 +92,7 @@ pip install raglite[ragas]
 ### 1. Configuring RAGLite
 
 > [!TIP]
-> 🧠 RAGLite extends [LiteLLM](https://github.com/BerriAI/litellm) with support for [llama.cpp](https://github.com/ggerganov/llama.cpp) models using [llama-cpp-python](https://github.com/abetlen/llama-cpp-python). To select a llama.cpp model (e.g., from [bartowski's collection](https://huggingface.co/bartowski)), use a model identifier of the form `"llama-cpp-python/<hugging_face_repo_id>/<filename>@<n_ctx>"`, where `n_ctx` is an optional parameter that specifies the context size of the model.
+> 🧠 RAGLite extends [LiteLLM](https://github.com/BerriAI/litellm) with support for [llama.cpp](https://github.com/ggerganov/llama.cpp) models using [llama-cpp-python](https://github.com/abetlen/llama-cpp-python). To select a llama.cpp model (e.g., from [Unsloth's collection](https://huggingface.co/unsloth)), use a model identifier of the form `"llama-cpp-python/<hugging_face_repo_id>/<filename>@<n_ctx>"`, where `n_ctx` is an optional parameter that specifies the context size of the model.
 
 > [!TIP]
 > 💾 You can create a PostgreSQL database in a few clicks at [neon.tech](https://neon.tech).
@@ -112,7 +112,7 @@ my_config = RAGLiteConfig(
 # Example 'local' config with a SQLite database and a llama.cpp LLM:
 my_config = RAGLiteConfig(
     db_url="sqlite:///raglite.db",
-    llm="llama-cpp-python/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/*Q4_K_M.gguf@8192",
+    llm="llama-cpp-python/unsloth/Qwen3-8B-GGUF/*Q4_K_M.gguf@8192",
     embedder="llama-cpp-python/lm-kit/bge-m3-gguf/*F16.gguf@1024",  # A context size of 1024 tokens is the sweet spot for bge-m3
 )
 ```
@@ -308,7 +308,7 @@ RAGLite comes with an [MCP server](https://modelcontextprotocol.io) implemented 
 ```
 raglite \
     --db-url sqlite:///raglite.db \
-    --llm llama-cpp-python/bartowski/Llama-3.2-3B-Instruct-GGUF/*Q4_K_M.gguf@4096 \
+    --llm llama-cpp-python/unsloth/Qwen3-4B-GGUF/*Q4_K_M.gguf@4096 \
     --embedder llama-cpp-python/lm-kit/bge-m3-gguf/*F16.gguf@1024 \
     mcp install
 ```
@@ -344,7 +344,7 @@ You can specify the database URL, LLM, and embedder directly in the Chainlit fro
 ```sh
 raglite \
     --db-url sqlite:///raglite.db \
-    --llm llama-cpp-python/bartowski/Llama-3.2-3B-Instruct-GGUF/*Q4_K_M.gguf@4096 \
+    --llm llama-cpp-python/unsloth/Qwen3-4B-GGUF/*Q4_K_M.gguf@4096 \
     --embedder llama-cpp-python/lm-kit/bge-m3-gguf/*F16.gguf@1024 \
     chainlit
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "scipy (>=1.11.2,!=1.15.0.*,!=1.15.1,!=1.15.2)",
   "wtpsplit-lite (>=0.1.0)",
   # Large Language Models:
-  "huggingface-hub (>=0.22.0)",
+  "huggingface-hub[hf_xet] (>=0.30.0)",
   "litellm (>=1.60.2)",
   "pydantic (>=2.7.0)",
   # Approximate Nearest Neighbors:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ dev = [
 # Frontend:
 chainlit = ["chainlit (>=2.0.0)"]
 # Large Language Models:
-llama-cpp-python = ["llama-cpp-python (>=0.3.4)"]
+llama-cpp-python = ["llama-cpp-python (>=0.3.9)"]
 # Markdown conversion:
 pandoc = ["pypandoc-binary (>=1.13)"]
 # Evaluation:

--- a/src/raglite/_chatml_function_calling.py
+++ b/src/raglite/_chatml_function_calling.py
@@ -6,6 +6,9 @@ Changes:
     b. ✨ Add function descriptions to the system message so that tool use is better informed (fixes https://github.com/abetlen/llama-cpp-python/issues/1869).
     c. ✨ Replace `print` statements relating to JSON grammars with `RuntimeWarning` warnings.
     d. ✅ Add tests with fairly broad coverage of the different scenarios.
+    e. 🐛 Fix a 'content' KeyError in the prompt template.
+    f. ✨ Add support for Qwen3's <|endoftext|> separator.
+    g. ✨ Add support for Qwen3's <think>...</think> mode to (auto and fixed) function calling.
 4. Case "Tool choice by user":
     a. ✨ Add support for more than one function call by making this a special case of "Automatic tool choice" with a single tool (subsumes https://github.com/abetlen/llama-cpp-python/pull/1503).
 5. Case "Automatic tool choice -> respond with a message":

--- a/src/raglite/_chatml_function_calling.py
+++ b/src/raglite/_chatml_function_calling.py
@@ -426,12 +426,10 @@ def chatml_function_calling_with_streaming(
         ),
     )
     text = completion["choices"][0]["text"]
-    think_text = text.split("</think>\n\n", maxsplit=1)
-    if len(think_text) == 2:  # noqa: PLR2004
-        prompt += think_text[0] + "</think>\n\n"
-        text = think_text[1].strip()
-    else:
-        text = think_text[0].strip()
+    if "</think>\n\n" in text:
+        think, text = text.split("</think>\n\n", maxsplit=1)
+        prompt += think + "</think>\n\n"
+    text = text.strip()
     tool_name = (
         None
         if text.startswith("message")

--- a/src/raglite/_config.py
+++ b/src/raglite/_config.py
@@ -31,9 +31,9 @@ class RAGLiteConfig:
     # LLM config used for generation.
     llm: str = field(
         default_factory=lambda: (
-            "llama-cpp-python/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/*Q4_K_M.gguf@8192"
+            "llama-cpp-python/unsloth/Qwen3-8B-GGUF/*Q4_K_M.gguf@8192"
             if llama_supports_gpu_offload()
-            else "llama-cpp-python/bartowski/Llama-3.2-3B-Instruct-GGUF/*Q4_K_M.gguf@4096"
+            else "llama-cpp-python/unsloth/Qwen3-4B-GGUF/*Q4_K_M.gguf@4096"
         )
     )
     llm_max_tries: int = 4

--- a/src/raglite/_litellm.py
+++ b/src/raglite/_litellm.py
@@ -55,7 +55,7 @@ class LlamaCppPythonLLM(CustomLLM):
     from litellm import completion
 
     response = completion(
-        model="llama-cpp-python/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/*Q4_K_M.gguf@4092",
+        model="llama-cpp-python/unsloth/Qwen3-8B-GGUF/*Q4_K_M.gguf@8192",
         messages=[{"role": "user", "content": "Hello world!"}],
         # stream=True
     )

--- a/src/raglite/_litellm.py
+++ b/src/raglite/_litellm.py
@@ -165,6 +165,17 @@ class LlamaCppPythonLLM(CustomLLM):
             }
         return llama_cpp_python_params
 
+    def _add_recommended_model_params(
+        self, model: str, llama_cpp_python_params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Add recommended model settings."""
+        recommended_settings = {}
+        if "qwen3" in model.lower():
+            # Add the official recommended 'thinking mode' settings [1].
+            # [1] https://docs.unsloth.ai/basics/qwen3-how-to-run-and-fine-tune#official-recommended-settings
+            recommended_settings = {"temperature": 0.6, "min_p": 0.0, "top_p": 0.95, "top_k": 20}
+        return {**recommended_settings, **llama_cpp_python_params}
+
     def completion(  # noqa: PLR0913
         self,
         model: str,
@@ -186,6 +197,7 @@ class LlamaCppPythonLLM(CustomLLM):
     ) -> ModelResponse:
         llm = self.llm(model)
         llama_cpp_python_params = self._translate_openai_params(optional_params)
+        llama_cpp_python_params = self._add_recommended_model_params(model, llama_cpp_python_params)
         response = cast(
             "llama_types.CreateChatCompletionResponse",
             llm.create_chat_completion(messages=messages, **llama_cpp_python_params),
@@ -219,6 +231,7 @@ class LlamaCppPythonLLM(CustomLLM):
     ) -> Iterator[GenericStreamingChunk]:
         llm = self.llm(model)
         llama_cpp_python_params = self._translate_openai_params(optional_params)
+        llama_cpp_python_params = self._add_recommended_model_params(model, llama_cpp_python_params)
         stream = cast(
             "Iterator[llama_types.CreateChatCompletionStreamResponse]",
             llm.create_chat_completion(messages=messages, **llama_cpp_python_params, stream=True),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,10 +70,10 @@ def database(request: pytest.FixtureRequest) -> str:
     params=[
         pytest.param(
             (
-                "llama-cpp-python/unsloth/Qwen3-4B-GGUF/*Q4_K_M.gguf@4096",
+                "llama-cpp-python/unsloth/Qwen3-1.7B-GGUF/*Q4_K_M.gguf@4096",
                 "llama-cpp-python/lm-kit/bge-m3-gguf/*Q4_K_M.gguf@1024",  # More context degrades performance.
             ),
-            id="qwen3_4B-bge_m3",
+            id="qwen3_1.7B-bge_m3",
         ),
         pytest.param(
             ("gpt-4o-mini", "text-embedding-3-small"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,10 +70,10 @@ def database(request: pytest.FixtureRequest) -> str:
     params=[
         pytest.param(
             (
-                "llama-cpp-python/unsloth/Qwen3-1.7B-GGUF/*Q4_K_M.gguf@4096",
+                "llama-cpp-python/bartowski/Llama-3.2-3B-Instruct-GGUF/*Q4_K_M.gguf@4096",
                 "llama-cpp-python/lm-kit/bge-m3-gguf/*Q4_K_M.gguf@1024",  # More context degrades performance.
             ),
-            id="qwen3_1.7B-bge_m3",
+            id="llama_3.2_3B-bge_m3",
         ),
         pytest.param(
             ("gpt-4o-mini", "text-embedding-3-small"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,10 +70,10 @@ def database(request: pytest.FixtureRequest) -> str:
     params=[
         pytest.param(
             (
-                "llama-cpp-python/bartowski/Llama-3.2-3B-Instruct-GGUF/*Q4_K_M.gguf@4096",
+                "llama-cpp-python/unsloth/Qwen3-4B-GGUF/*Q4_K_M.gguf@4096",
                 "llama-cpp-python/lm-kit/bge-m3-gguf/*Q4_K_M.gguf@1024",  # More context degrades performance.
             ),
-            id="llama_3.2_3B-bge_m3",
+            id="qwen3_4B-bge_m3",
         ),
         pytest.param(
             ("gpt-4o-mini", "text-embedding-3-small"),

--- a/tests/test_chatml_function_calling.py
+++ b/tests/test_chatml_function_calling.py
@@ -59,7 +59,7 @@ def is_accelerator_available() -> bool:
 @pytest.mark.parametrize(
     "llm_repo_id",
     [
-        pytest.param("unsloth/Qwen3-1.7B-GGUF", id="qwen3_1.7B"),
+        pytest.param("bartowski/Llama-3.2-3B-Instruct-GGUF", id="llama_3.2_3B"),
         pytest.param(
             "unsloth/Qwen3-8B-GGUF",
             id="qwen3_8B",

--- a/tests/test_chatml_function_calling.py
+++ b/tests/test_chatml_function_calling.py
@@ -59,10 +59,10 @@ def is_accelerator_available() -> bool:
 @pytest.mark.parametrize(
     "llm_repo_id",
     [
-        pytest.param("bartowski/Llama-3.2-3B-Instruct-GGUF", id="llama_3.2_3B"),
+        pytest.param("unsloth/Qwen3-4B-GGUF", id="qwen3_4B"),
         pytest.param(
-            "bartowski/Meta-Llama-3.1-8B-Instruct-GGUF",
-            id="llama_3.1_8B",
+            "unsloth/Qwen3-8B-GGUF",
+            id="qwen3_8B",
             marks=pytest.mark.skipif(
                 not is_accelerator_available(), reason="Accelerator not available"
             ),

--- a/tests/test_chatml_function_calling.py
+++ b/tests/test_chatml_function_calling.py
@@ -59,7 +59,7 @@ def is_accelerator_available() -> bool:
 @pytest.mark.parametrize(
     "llm_repo_id",
     [
-        pytest.param("unsloth/Qwen3-4B-GGUF", id="qwen3_4B"),
+        pytest.param("unsloth/Qwen3-1.7B-GGUF", id="qwen3_1.7B"),
         pytest.param(
             "unsloth/Qwen3-8B-GGUF",
             id="qwen3_8B",


### PR DESCRIPTION
This PR adds support for [Qwen3](https://qwenlm.github.io/blog/qwen3/) and reasoning tool use. [Qwen3 8B in 4bit is currently Simon Willison's favourite model](https://x.com/simonw/status/1918451927207325774). Reasoning can be disabled by adding `/no_think` to any message.

Changes:
1. Upgrade llama-cpp-python to >=0.3.9, which has a newer version of llama.cpp that supports Qwen3.
2. Replace Llama 3.1 8B and 3.2 3B with Qwen3 8B and 4B, respectively.
3. Recommend using Unsloth GGUF's in the README. They recently introduced [Dynamic 2.0 GGUFs](https://unsloth.ai/blog/dynamic-v2) and are probably the highest quality quants available today.
4. Add the `hf_xet` extra to huggingface-hub for better performance.
5. Upgrade the `chatml-function-calling` handler with support for reasoning before tool use.
6. Apply [Qwen3's recommended model settings](https://docs.unsloth.ai/basics/qwen3-how-to-run-and-fine-tune#official-recommended-settings) if a Qwen3 model is selected.