### PR TITLE
feat: add front matter to chunk content

### DIFF
--- a/src/raglite/_database.py
+++ b/src/raglite/_database.py
@@ -185,13 +185,18 @@ class Chunk(SQLModel, table=True):
     @property
     def front_matter(self) -> str:
         """Return this chunk's front matter."""
-        filename = self.metadata_.get("filename")
-        url = self.metadata_.get("url")
-        if filename and url:
-            return f"<!-- [{filename}]({url}) -->"
-        elif filename or url:  # noqa: RET505
-            return f"<!-- {filename or url} -->"
-        return ""
+        # Compose the chunk metadata from the filename and URL.
+        metadata = "\n".join(
+            f"{key}: {self.metadata_.get(key)}"
+            for key in ("filename", "url")
+            if self.metadata_.get(key)
+        )
+        if not metadata:
+            return ""
+        # Return the chunk metadata in the YAML front matter format [1].
+        # [1] https://jekyllrb.com/docs/front-matter/
+        front_matter = f"---\n{metadata}\n---"
+        return front_matter
 
     @property
     def content(self) -> str:

--- a/src/raglite/_insert.py
+++ b/src/raglite/_insert.py
@@ -14,11 +14,11 @@ from raglite._embed import embed_sentences, embed_strings, sentence_embedding_ty
 from raglite._markdown import document_to_markdown
 from raglite._split_chunks import split_chunks
 from raglite._split_sentences import split_sentences
-from raglite._typing import DocumentId, FloatMatrix
+from raglite._typing import FloatMatrix
 
 
 def _create_chunk_records(
-    document_id: DocumentId,
+    document: Document,
     chunks: list[str],
     chunk_embeddings: list[FloatMatrix],
     metadata: dict[str, str],
@@ -30,7 +30,7 @@ def _create_chunk_records(
     for i, chunk in enumerate(chunks):
         # Create and append the chunk record.
         record = Chunk.from_body(
-            document_id=document_id, index=i, body=chunk, headings=headings, **metadata
+            document=document, index=i, body=chunk, headings=headings, **metadata
         )
         chunk_records.append(record)
         # Update the Markdown headings with those of this chunk.
@@ -147,7 +147,7 @@ def insert_document(  # noqa: PLR0915
             session.add(document_record)
             for chunk_record, chunk_embedding_record_list in zip(
                 *_create_chunk_records(
-                    document_record.id, chunks, chunk_embeddings, metadata or {}, config
+                    document_record, chunks, chunk_embeddings, metadata or {}, config
                 ),
                 strict=True,
             ):


### PR DESCRIPTION
This PR adds front matter to the chunk representation for embedding with the document's filename and/or URL. In the absence of contextual Markdown headings, the front matter can help provide context to the embedder about the chunk.