### PR TITLE
feat: rank chunks by the L∞ norm of their multi-vector similarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,26 +81,13 @@ pip install raglite[ragas]
 
 ### Overview
 
-- [🥤 RAGLite](#-raglite)
-  - [Features](#features)
-        - [Configurable](#configurable)
-        - [Fast and permissive](#fast-and-permissive)
-        - [Unhobbled](#unhobbled)
-        - [Extensible](#extensible)
-  - [Installing](#installing)
-  - [Using](#using)
-    - [Overview](#overview)
-    - [1. Configuring RAGLite](#1-configuring-raglite)
-    - [2. Inserting documents](#2-inserting-documents)
-    - [3. Retrieval-Augmented Generation (RAG)](#3-retrieval-augmented-generation-rag)
-      - [3.1 Adaptive RAG](#31-adaptive-rag)
-      - [3.2 Programmable RAG](#32-programmable-rag)
-    - [4. Computing and using an optimal query adapter](#4-computing-and-using-an-optimal-query-adapter)
-    - [5. Evaluation of retrieval and generation](#5-evaluation-of-retrieval-and-generation)
-    - [6. Running a Model Context Protocol (MCP) server](#6-running-a-model-context-protocol-mcp-server)
-    - [7. Serving a customizable ChatGPT-like frontend](#7-serving-a-customizable-chatgpt-like-frontend)
-  - [Contributing](#contributing)
-  - [Star History](#star-history)
+1. [Configuring RAGLite](#1-configuring-raglite)
+2. [Inserting documents](#2-inserting-documents)
+3. [Retrieval-Augmented Generation (RAG)](#3-retrieval-augmented-generation-rag)
+4. [Computing and using an optimal query adapter](#4-computing-and-using-an-optimal-query-adapter)
+5. [Evaluation of retrieval and generation](#5-evaluation-of-retrieval-and-generation)
+6. [Running a Model Context Protocol (MCP) server](#6-running-a-model-context-protocol-mcp-server)
+7. [Serving a customizable ChatGPT-like frontend](#7-serving-a-customizable-chatgpt-like-frontend)
 
 ### 1. Configuring RAGLite
 

--- a/README.md
+++ b/README.md
@@ -81,13 +81,26 @@ pip install raglite[ragas]
 
 ### Overview
 
-1. [Configuring RAGLite](#1-configuring-raglite)
-2. [Inserting documents](#2-inserting-documents)
-3. [Retrieval-Augmented Generation (RAG)](#3-retrieval-augmented-generation-rag)
-4. [Computing and using an optimal query adapter](#4-computing-and-using-an-optimal-query-adapter)
-5. [Evaluation of retrieval and generation](#5-evaluation-of-retrieval-and-generation)
-6. [Running a Model Context Protocol (MCP) server](#6-running-a-model-context-protocol-mcp-server)
-7. [Serving a customizable ChatGPT-like frontend](#7-serving-a-customizable-chatgpt-like-frontend)
+- [🥤 RAGLite](#-raglite)
+  - [Features](#features)
+        - [Configurable](#configurable)
+        - [Fast and permissive](#fast-and-permissive)
+        - [Unhobbled](#unhobbled)
+        - [Extensible](#extensible)
+  - [Installing](#installing)
+  - [Using](#using)
+    - [Overview](#overview)
+    - [1. Configuring RAGLite](#1-configuring-raglite)
+    - [2. Inserting documents](#2-inserting-documents)
+    - [3. Retrieval-Augmented Generation (RAG)](#3-retrieval-augmented-generation-rag)
+      - [3.1 Adaptive RAG](#31-adaptive-rag)
+      - [3.2 Programmable RAG](#32-programmable-rag)
+    - [4. Computing and using an optimal query adapter](#4-computing-and-using-an-optimal-query-adapter)
+    - [5. Evaluation of retrieval and generation](#5-evaluation-of-retrieval-and-generation)
+    - [6. Running a Model Context Protocol (MCP) server](#6-running-a-model-context-protocol-mcp-server)
+    - [7. Serving a customizable ChatGPT-like frontend](#7-serving-a-customizable-chatgpt-like-frontend)
+  - [Contributing](#contributing)
+  - [Star History](#star-history)
 
 ### 1. Configuring RAGLite
 
@@ -113,7 +126,7 @@ my_config = RAGLiteConfig(
 my_config = RAGLiteConfig(
     db_url="sqlite:///raglite.db",
     llm="llama-cpp-python/unsloth/Qwen3-8B-GGUF/*Q4_K_M.gguf@8192",
-    embedder="llama-cpp-python/lm-kit/bge-m3-gguf/*F16.gguf@1024",  # A context size of 1024 tokens is the sweet spot for bge-m3
+    embedder="llama-cpp-python/lm-kit/bge-m3-gguf/*F16.gguf@512", # More than 512 tokens degrades bge-m3's performance
 )
 ```
 
@@ -309,7 +322,7 @@ RAGLite comes with an [MCP server](https://modelcontextprotocol.io) implemented 
 raglite \
     --db-url sqlite:///raglite.db \
     --llm llama-cpp-python/unsloth/Qwen3-4B-GGUF/*Q4_K_M.gguf@8192 \
-    --embedder llama-cpp-python/lm-kit/bge-m3-gguf/*F16.gguf@1024 \
+    --embedder llama-cpp-python/lm-kit/bge-m3-gguf/*F16.gguf@512 \
     mcp install
 ```
 
@@ -345,7 +358,7 @@ You can specify the database URL, LLM, and embedder directly in the Chainlit fro
 raglite \
     --db-url sqlite:///raglite.db \
     --llm llama-cpp-python/unsloth/Qwen3-4B-GGUF/*Q4_K_M.gguf@8192 \
-    --embedder llama-cpp-python/lm-kit/bge-m3-gguf/*F16.gguf@1024 \
+    --embedder llama-cpp-python/lm-kit/bge-m3-gguf/*F16.gguf@512 \
     chainlit
 ```
 

--- a/src/raglite/_config.py
+++ b/src/raglite/_config.py
@@ -51,7 +51,6 @@ class RAGLiteConfig:
     # Vector search config.
     vector_search_index_metric: Literal["cosine"] = "cosine"
     vector_search_multivector: bool = True
-    vector_search_similarity_norm: int = 2
     vector_search_query_adapter: bool = True  # Only supported for "cosine" and "dot" metrics.
     # Reranking config.
     reranker: BaseRanker | tuple[tuple[str, BaseRanker], ...] | None = field(

--- a/src/raglite/_config.py
+++ b/src/raglite/_config.py
@@ -40,18 +40,19 @@ class RAGLiteConfig:
     # Embedder config used for indexing.
     embedder: str = field(
         default_factory=lambda: (  # Nomic-embed may be better if only English is used.
-            "llama-cpp-python/lm-kit/bge-m3-gguf/*F16.gguf@1024"
+            "llama-cpp-python/lm-kit/bge-m3-gguf/*F16.gguf@512"
             if llama_supports_gpu_offload() or (os.cpu_count() or 1) >= 4  # noqa: PLR2004
-            else "llama-cpp-python/lm-kit/bge-m3-gguf/*Q4_K_M.gguf@1024"
+            else "llama-cpp-python/lm-kit/bge-m3-gguf/*Q4_K_M.gguf@512"
         )
     )
     embedder_normalize: bool = True
     # Chunk config used to partition documents into chunks.
     chunk_max_size: int = 2048  # Max number of characters per chunk.
     # Vector search config.
-    vector_search_index_metric: Literal["cosine", "dot", "l1", "l2"] = "cosine"
-    vector_search_query_adapter: bool = True  # Only supported for "cosine" and "dot" metrics.
+    vector_search_index_metric: Literal["cosine"] = "cosine"
     vector_search_multivector: bool = True
+    vector_search_similarity_norm: int = 2
+    vector_search_query_adapter: bool = True  # Only supported for "cosine" and "dot" metrics.
     # Reranking config.
     reranker: BaseRanker | tuple[tuple[str, BaseRanker], ...] | None = field(
         default_factory=lambda: (

--- a/src/raglite/_database.py
+++ b/src/raglite/_database.py
@@ -441,7 +441,7 @@ def create_database_engine(config: RAGLiteConfig | None = None) -> Engine:
                     (embedding::halfvec({embedding_dim}))
                     halfvec_{metrics[config.vector_search_index_metric]}_ops
                 );
-                SET hnsw.ef_search = {20 * 4 * 8};
+                SET hnsw.ef_search = {(10 * 4) * 4};
             """
             # Enable iterative scan for pgvector v0.8.0 and up.
             pgvector_version = _pgvector_version(session)

--- a/src/raglite/_insert.py
+++ b/src/raglite/_insert.py
@@ -56,7 +56,7 @@ def _create_chunk_records(
         # Every chunk record is associated with a list of chunk embedding records. The chunk
         # embedding records each correspond to a linear combination of a chunklet embedding and an
         # embedding of the full chunk with Markdown headings.
-        α = 0.382  # Golden ratio.  # noqa: PLC2401
+        α = 0.15  # Golden ratio.  # noqa: PLC2401
         for chunk_record, chunk_embedding, full_chunk_embedding in zip(
             chunk_records, chunk_embeddings, full_chunk_embeddings, strict=True
         ):

--- a/src/raglite/_insert.py
+++ b/src/raglite/_insert.py
@@ -56,7 +56,7 @@ def _create_chunk_records(
         # Every chunk record is associated with a list of chunk embedding records. The chunk
         # embedding records each correspond to a linear combination of a chunklet embedding and an
         # embedding of the full chunk with Markdown headings.
-        α = 0.15  # Golden ratio.  # noqa: PLC2401
+        α = 0.15  # Benchmark-optimised value.  # noqa: PLC2401
         for chunk_record, chunk_embedding, full_chunk_embedding in zip(
             chunk_records, chunk_embeddings, full_chunk_embeddings, strict=True
         ):

--- a/src/raglite/_query_adapter.py
+++ b/src/raglite/_query_adapter.py
@@ -146,15 +146,15 @@ def update_query_adapter(  # noqa: PLR0915, C901
         MT = (α[:, np.newaxis] * (P - N)).T @ Q  # noqa: N806
         s = np.linalg.norm(MT, ord="fro") / np.sqrt(MT.shape[0])
         MT = np.mean(α) * (MT / s) + np.mean(1 - α) * np.eye(Q.shape[1])  # noqa: N806
-        if config.vector_search_index_metric == "dot":
+        if config.vector_search_index_metric == "dot":  # type: ignore[comparison-overlap]
             # Use the relaxed Procrustes solution.
-            A_star = MT / np.linalg.norm(MT, ord="fro")  # noqa: N806
+            A_star = MT / np.linalg.norm(MT, ord="fro")  # type: ignore[unreachable]  # noqa: N806
         elif config.vector_search_index_metric == "cosine":
             # Use the orthogonal Procrustes solution.
             U, _, VT = np.linalg.svd(MT, full_matrices=False)  # noqa: N806
             A_star = U @ VT  # noqa: N806
         else:
-            error_message = f"Unsupported ANN metric: {config.vector_search_index_metric}"
+            error_message = f"Unsupported ANN metric: {config.vector_search_index_metric}"  # type: ignore[unreachable]
             raise ValueError(error_message)
         # Store the optimal query adapter in the database.
         index_metadata = session.get(IndexMetadata, "default") or IndexMetadata(id="default")

--- a/src/raglite/_search.py
+++ b/src/raglite/_search.py
@@ -29,7 +29,7 @@ def vector_search(
     query: str | FloatMatrix,
     *,
     num_results: int = 3,
-    oversample: int = 8,
+    oversample: int = 4,
     config: RAGLiteConfig | None = None,
 ) -> tuple[list[ChunkId], list[float]]:
     """Search chunks using ANN vector search."""

--- a/src/raglite/_search.py
+++ b/src/raglite/_search.py
@@ -11,7 +11,7 @@ import numpy as np
 from langdetect import LangDetectException, detect
 from sqlalchemy.engine import make_url
 from sqlalchemy.orm import joinedload
-from sqlmodel import Session, and_, col, or_, select, text
+from sqlmodel import Session, and_, col, func, or_, select, text
 
 from raglite._config import RAGLiteConfig
 from raglite._database import (
@@ -47,27 +47,34 @@ def vector_search(
     if config.vector_search_query_adapter and Q is not None:
         query_embedding = (Q @ query_embedding).astype(query_embedding.dtype)
     # Search for the multi-vector chunk embeddings that are most similar to the query embedding.
+    p = config.vector_search_similarity_norm
+    if not (np.isfinite(p) and p >= 1):
+        error_message = "The value of config.vector_search_similarity_norm must be in [1, ∞)."
+        raise ValueError(error_message)
     if db_backend == "postgresql":
-        # Check that the selected metric is supported by pgvector.
-        metrics = {"cosine": "<=>", "dot": "<#>", "euclidean": "<->", "l1": "<+>", "l2": "<->"}
-        if config.vector_search_index_metric not in metrics:
-            error_message = f"Unsupported metric {config.vector_search_index_metric}."
-            raise ValueError(error_message)
-        # With pgvector, we can obtain the nearest neighbours and similarities with a single query.
+        # Rank the chunks by relevance according to the Lp-norm of the similarities of the
+        # multi-vector chunk embeddings to the query embedding with a single query.
         engine = create_database_engine(config)
         with Session(engine) as session:
-            distance_func = getattr(
-                ChunkEmbedding.embedding, f"{config.vector_search_index_metric}_distance"
-            )
-            distance = distance_func(query_embedding).label("distance")
-            results = session.exec(
-                select(ChunkEmbedding.chunk_id, distance)
-                .order_by(distance)
+            dist = ChunkEmbedding.embedding.cosine_distance(query_embedding).label("dist")  # type: ignore[attr-defined]
+            sim = (1.0 - dist).label("sim")
+            top_vectors = (
+                select(ChunkEmbedding.chunk_id, sim)
+                .where(sim > 0)
+                .order_by(dist)
                 .limit(oversample * num_results)
+                .subquery()
             )
-            results = list(results)  # type: ignore[assignment]
-            chunk_ids = np.asarray([result[0] for result in results])
-            similarity = 1.0 - np.asarray([result[1] for result in results])
+            sim_norm = func.pow(func.sum(func.pow(func.abs(top_vectors.c.sim), p)), 1.0 / p)
+            statement = (
+                select(top_vectors.c.chunk_id, sim_norm)
+                .group_by(top_vectors.c.chunk_id)
+                .order_by(sim_norm.desc())
+                .limit(num_results)
+            )
+            rows = session.exec(statement).all()
+            chunk_ids = [row[0] for row in rows]
+            similarity = [float(row[1]) for row in rows]
     elif db_backend == "sqlite":
         # Load the NNDescent index.
         index = index_metadata.get("index")
@@ -78,33 +85,25 @@ def vector_search(
 
         if isinstance(index, NNDescent) and len(ids) and len(cumsum):
             # Query the index.
-            multi_vector_indices, distance = index.query(
-                query_embedding[np.newaxis, :], k=oversample * num_results
+            multivector_indices, dist = index.query(
+                query_embedding[np.newaxis, :], k=min(oversample * num_results, cumsum[-1])
             )
-            similarity = 1 - distance[0, :]
-            # Transform the multi-vector indices into chunk indices, and then to chunk ids.
-            chunk_indices = np.searchsorted(cumsum, multi_vector_indices[0, :], side="right") + 1
-            chunk_ids = np.asarray([ids[chunk_index - 1] for chunk_index in chunk_indices])
+            # Transform the multi-vector indices into chunk indices.
+            chunk_indices = np.searchsorted(cumsum, multivector_indices[0, :], side="right")
+            # Compute the Lp-norm of the similarities of the multi-vector chunk embeddings.
+            sim_clip = np.maximum(1 - dist[0], 0.0)
+            lp_norm = np.bincount(chunk_indices, weights=np.abs(sim_clip) ** p, minlength=len(ids))
+            lp_norm = np.power(lp_norm, 1.0 / p)
+            # Efficiently find the top chunks.
+            num_results = min(num_results, len(ids))
+            top_k = np.argpartition(lp_norm, -num_results)[-num_results:]
+            top_k = top_k[np.argsort(lp_norm[top_k])[::-1]]
+            chunk_ids = [i for i, s in zip(ids[top_k], lp_norm[top_k], strict=True) if s > 0]
+            similarity = [float(s) for s in lp_norm[top_k] if s > 0]
         else:
             # Empty result set if there is no index or if no chunks are indexed.
-            chunk_ids, similarity = np.array([], dtype=np.intp), np.array([])
-    # Exit early if there are no search results.
-    if not len(chunk_ids):
-        return [], []
-    # Score each unique chunk id as the mean similarity of its multi-vector hits. Chunk ids with
-    # fewer hits are padded with the minimum similarity of the result set.
-    unique_chunk_ids, counts = np.unique(chunk_ids, return_counts=True)
-    score = np.full(
-        (len(unique_chunk_ids), np.max(counts)), np.min(similarity), dtype=similarity.dtype
-    )
-    for i, (unique_chunk_id, count) in enumerate(zip(unique_chunk_ids, counts, strict=True)):
-        score[i, :count] = similarity[chunk_ids == unique_chunk_id]
-    pooled_similarity = np.mean(score, axis=1)
-    # Sort the chunk ids by their adjusted similarity.
-    sorted_indices = np.argsort(pooled_similarity)[::-1]
-    unique_chunk_ids = unique_chunk_ids[sorted_indices][:num_results]
-    pooled_similarity = pooled_similarity[sorted_indices][:num_results]
-    return unique_chunk_ids.tolist(), pooled_similarity.tolist()
+            chunk_ids, similarity = [], []
+    return chunk_ids, similarity
 
 
 def keyword_search(

--- a/src/raglite/_search.py
+++ b/src/raglite/_search.py
@@ -48,6 +48,7 @@ def vector_search(
         query_embedding = (Q @ query_embedding).astype(query_embedding.dtype)
     # Search for the multi-vector chunk embeddings that are most similar to the query embedding.
     p = config.vector_search_similarity_norm
+    num_hits = oversample * max(num_results, 10)
     if not (np.isfinite(p) and p >= 1):
         error_message = "The value of config.vector_search_similarity_norm must be in [1, ∞)."
         raise ValueError(error_message)
@@ -62,7 +63,7 @@ def vector_search(
                 select(ChunkEmbedding.chunk_id, sim)
                 .where(sim > 0)
                 .order_by(dist)
-                .limit(oversample * num_results)
+                .limit(num_hits)
                 .subquery()
             )
             sim_norm = func.pow(func.sum(func.pow(func.abs(top_vectors.c.sim), p)), 1.0 / p)
@@ -86,7 +87,7 @@ def vector_search(
         if isinstance(index, NNDescent) and len(ids) and len(cumsum):
             # Query the index.
             multivector_indices, dist = index.query(
-                query_embedding[np.newaxis, :], k=min(oversample * num_results, cumsum[-1])
+                query_embedding[np.newaxis, :], k=min(num_hits, cumsum[-1])
             )
             # Transform the multi-vector indices into chunk indices.
             chunk_indices = np.searchsorted(cumsum, multivector_indices[0, :], side="right")

--- a/src/raglite/_search.py
+++ b/src/raglite/_search.py
@@ -29,7 +29,7 @@ def vector_search(
     query: str | FloatMatrix,
     *,
     num_results: int = 3,
-    oversample: int = 4,
+    oversample: int = 8,
     config: RAGLiteConfig | None = None,
 ) -> tuple[list[ChunkId], list[float]]:
     """Search chunks using ANN vector search."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,7 +71,7 @@ def database(request: pytest.FixtureRequest) -> str:
         pytest.param(
             (
                 "llama-cpp-python/unsloth/Qwen3-4B-GGUF/*Q4_K_M.gguf@8192",
-                "llama-cpp-python/lm-kit/bge-m3-gguf/*Q4_K_M.gguf@1024",  # More context degrades performance.
+                "llama-cpp-python/lm-kit/bge-m3-gguf/*Q4_K_M.gguf@512",  # More context degrades performance.
             ),
             id="qwen3_4B-bge_m3",
         ),

--- a/tests/test_rerank.py
+++ b/tests/test_rerank.py
@@ -8,7 +8,7 @@ from rerankers.models.flashrank_ranker import FlashRankRanker
 from rerankers.models.ranker import BaseRanker
 from scipy.stats import kendalltau
 
-from raglite import RAGLiteConfig, hybrid_search, rerank_chunks, retrieve_chunks
+from raglite import RAGLiteConfig, rerank_chunks, retrieve_chunks, vector_search
 from raglite._database import Chunk
 
 T = TypeVar("T")
@@ -52,7 +52,7 @@ def test_reranker(
     )
     # Search for a query.
     query = "What does it mean for two events to be simultaneous?"
-    chunk_ids, _ = hybrid_search(query, num_results=20, config=raglite_test_config)
+    chunk_ids, _ = vector_search(query, num_results=20, config=raglite_test_config)
     # Retrieve the chunks.
     chunks = retrieve_chunks(chunk_ids, config=raglite_test_config)
     assert all(isinstance(chunk, Chunk) for chunk in chunks)

--- a/tests/test_rerank.py
+++ b/tests/test_rerank.py
@@ -67,7 +67,4 @@ def test_reranker(
             τ_search = kendall_tau(chunks, reranked_chunks)  # noqa: PLC2401
             τ_inverse = kendall_tau(chunks[::-1], reranked_chunks)  # noqa: PLC2401
             τ_random = kendall_tau(chunks_random, reranked_chunks)  # noqa: PLC2401
-            # TODO assert that τ_search >= τ_random >= τ_inverse
-            assert isinstance(τ_search, float)
-            assert isinstance(τ_inverse, float)
-            assert isinstance(τ_random, float)
+            assert τ_search >= τ_random >= τ_inverse

--- a/tests/test_rerank.py
+++ b/tests/test_rerank.py
@@ -52,7 +52,7 @@ def test_reranker(
     )
     # Search for a query.
     query = "What does it mean for two events to be simultaneous?"
-    chunk_ids, _ = vector_search(query, num_results=20, config=raglite_test_config)
+    chunk_ids, _ = vector_search(query, num_results=40, config=raglite_test_config)
     # Retrieve the chunks.
     chunks = retrieve_chunks(chunk_ids, config=raglite_test_config)
     assert all(isinstance(chunk, Chunk) for chunk in chunks)


### PR DESCRIPTION
This PR simplifies and improves the way vector search ranks chunks.

Before this PR, chunks were (more or less) ranked by descending L1 norm of their multi-vector similarities w.r.t. the query vector. The more relevant sentences in the chunk, the more relevant the chunk becomes. But it also means that the more sentences in the chunk, the more relevant the chunk becomes. On the other end of the spectrum is ranking by the L∞ norm, which means ranking chunks by the similarity of their most relevant sentence to the query vector.

After this PR, chunk are ranked by descending L∞ norm of their multi-vector similarities w.r.t. the query vector.

Changes:
1. In vector search, rank chunks according to the L∞ norm of their multi-vector (cosine) similarities.
2. Remove all vector search metrics except `"cosine"`. We can reintroduce support for other metrics later.
3. Reduce BGE-M3's context size from 1024 to 512 tokens, which markedly improves the vector search ranking's correlation with that of FlashRank.
4. Reintroduce `assert τ_search >= τ_random >= τ_inverse`, made possible by (4).
5. Optimize the pgvector's `ef_search` with the new oversample value so that it becomes 10 (chunks) * 4 (reranking) * 4 (multi-vector oversampling) = 160.