### PR TITLE
fix: fix off-by-one error in parsing of Markdown headings

### DIFF
--- a/src/raglite/_database.py
+++ b/src/raglite/_database.py
@@ -138,8 +138,7 @@ class Chunk(SQLModel, table=True):
             elif level is not None:
                 heading_content = token.content.strip().replace("\n", " ")
                 heading_lines[level - 1] = ("#" * level) + " " + heading_content
-                for i in range(level, 6):
-                    heading_lines[i] = ""
+                heading_lines[level:] = [""] * len(heading_lines[level:])
             elif leading_only and level is None and token.content and not token.content.isspace():
                 break
         return heading_lines

--- a/src/raglite/_database.py
+++ b/src/raglite/_database.py
@@ -138,7 +138,8 @@ class Chunk(SQLModel, table=True):
             elif level is not None:
                 heading_content = token.content.strip().replace("\n", " ")
                 heading_lines[level - 1] = ("#" * level) + " " + heading_content
-                heading_lines[level:] = [""] * len(heading_lines[level + 1 :])
+                for i in range(level, 6):
+                    heading_lines[i] = ""
             elif leading_only and level is None and token.content and not token.content.isspace():
                 break
         return heading_lines


### PR DESCRIPTION
The md header list would not consistently have length = 6. This caused a list assignment index out of range error
