### PR TITLE
feat: config for hybrid search

### DIFF
--- a/src/raglite/__init__.py
+++ b/src/raglite/__init__.py
@@ -11,6 +11,7 @@ from raglite._search import (
     rerank_chunks,
     retrieve_chunk_spans,
     retrieve_chunks,
+    search,
     vector_search,
 )
 
@@ -20,6 +21,7 @@ __all__ = [
     # Insert
     "insert_document",
     # Search
+    "search",
     "hybrid_search",
     "keyword_search",
     "vector_search",

--- a/src/raglite/_chainlit.py
+++ b/src/raglite/_chainlit.py
@@ -6,11 +6,11 @@ from pathlib import Path
 import chainlit as cl
 from chainlit.input_widget import Switch, TextInput
 
-from raglite import RAGLiteConfig, async_rag, hybrid_search, insert_document, rerank_chunks
+from raglite import RAGLiteConfig, async_rag, insert_document, rerank_chunks, search
 from raglite._markdown import document_to_markdown
 
 async_insert_document = cl.make_async(insert_document)
-async_hybrid_search = cl.make_async(hybrid_search)
+async_search = cl.make_async(search)
 async_rerank_chunks = cl.make_async(rerank_chunks)
 
 
@@ -53,7 +53,7 @@ async def update_config(settings: cl.ChatSettings) -> None:
     if str(config.db_url).startswith("sqlite") or config.embedder.startswith("llama-cpp-python"):
         # async with cl.Step(name="initialize", type="retrieval"):
         query = "Hello world"
-        chunk_ids, _ = await async_hybrid_search(query=query, config=config)
+        chunk_ids, _ = await async_search(query=query, config=config)
         _ = await async_rerank_chunks(query=query, chunk_ids=chunk_ids, config=config)
 
 

--- a/src/raglite/_config.py
+++ b/src/raglite/_config.py
@@ -52,6 +52,7 @@ class RAGLiteConfig:
     vector_search_index_metric: Literal["cosine"] = "cosine"
     vector_search_multivector: bool = True
     vector_search_query_adapter: bool = True  # Only supported for "cosine" and "dot" metrics.
+    hybrid_vector_search: bool = False
     # Reranking config.
     reranker: BaseRanker | tuple[tuple[str, BaseRanker], ...] | None = field(
         default_factory=lambda: (

--- a/src/raglite/_rag.py
+++ b/src/raglite/_rag.py
@@ -16,8 +16,7 @@ from litellm import (  # type: ignore[attr-defined]
 from raglite._config import RAGLiteConfig
 from raglite._database import ChunkSpan
 from raglite._litellm import get_context_size
-from raglite._search import hybrid_search, rerank_chunks, retrieve_chunk_spans
-from raglite._typing import SearchMethod
+from raglite._search import rerank_chunks, retrieve_chunk_spans, search
 
 # The default RAG instruction template follows Anthropic's best practices [1].
 # [1] https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/long-context-tips
@@ -38,7 +37,6 @@ def retrieve_rag_context(
     *,
     num_chunks: int = 5,
     chunk_neighbors: tuple[int, ...] | None = (-1, 1),
-    search: SearchMethod = hybrid_search,
     config: RAGLiteConfig | None = None,
 ) -> list[ChunkSpan]:
     """Retrieve context for RAG."""

--- a/src/raglite/_search.py
+++ b/src/raglite/_search.py
@@ -180,6 +180,17 @@ def hybrid_search(
     return chunk_ids, hybrid_score
 
 
+def search(
+    query: str, *, num_results: int = 3, oversample: int = 4, config: RAGLiteConfig | None = None
+) -> tuple[list[ChunkId], list[float]]:
+    config = config or RAGLiteConfig()
+    if config.hybrid_vector_search:
+        return hybrid_search(
+            query=query, num_results=num_results, oversample=oversample, config=config
+        )
+    return vector_search(query=query, num_results=num_results, oversample=oversample, config=config)
+
+
 def retrieve_chunks(
     chunk_ids: list[ChunkId], *, config: RAGLiteConfig | None = None
 ) -> list[Chunk]:


### PR DESCRIPTION
This PR adds a setting in config that determines whether to use hybrid or not. It then standardizes the search method to be used throughout the package, so that a user cannot mismatch the search methods that they use.

See https://github.com/superlinear-ai/raglite/issues/37