### PR TITLE
feat: enable weighted reciprocal rank fusion

### DIFF
--- a/src/raglite/_search.py
+++ b/src/raglite/_search.py
@@ -153,11 +153,11 @@ def reciprocal_rank_fusion(
     if weights is None:
         weights = [1.0] * len(rankings)
     if len(weights) != len(rankings):
-        error = "Weights do not match rankings"
+        error = "The number of weights must match the number of rankings."
         raise ValueError(error)
     # Compute the RRF score.
     chunk_id_score: defaultdict[str, float] = defaultdict(float)
-    for ranking, weight in zip(rankings, weights, strict=False):
+    for ranking, weight in zip(rankings, weights, strict=True):
         for i, chunk_id in enumerate(ranking):
             chunk_id_score[chunk_id] += weight / (k + i)
     # Exit early if there are no results to fuse.


### PR DESCRIPTION
Adding the functionality to the RRF function that we can pass weights to the rankings. This PR doesn't modify the hybrid search function yet to include the option to pass weights, should be done after https://github.com/superlinear-ai/raglite/pull/135 

One other major change to the rrf is done in this PR. Currently, we are assigning a value of 1/(k+len(chunk_id_index)) if a chunk index doesn't appear in the ranking. But I think it makes more sense to treat it as rank = \inf and just give a score of 0, i dont see a reason we would give 'points' for not being in the list. That also simplifies the logic a bit.

See https://github.com/superlinear-ai/raglite/issues/38