### PR TITLE
feat: improve config and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,10 +131,10 @@ my_config = RAGLiteConfig(
 # Example local cross-encoder reranker per language (this is the default):
 my_config = RAGLiteConfig(
     db_url="sqlite:///raglite.db",
-    reranker=(
-        ("en", Reranker("ms-marco-MiniLM-L-12-v2", model_type="flashrank")),  # English
-        ("other", Reranker("ms-marco-MultiBERT-L-12", model_type="flashrank")),  # Other languages
-    )
+    reranker={
+        "en": Reranker("ms-marco-MiniLM-L-12-v2", model_type="flashrank"),  # English
+        "other": Reranker("ms-marco-MultiBERT-L-12", model_type="flashrank"),  # Other languages
+    }
 )
 ```
 
@@ -196,15 +196,19 @@ The LLM will adaptively decide whether to retrieve information based on the comp
 If you need manual control over the RAG pipeline, you can run a basic but powerful pipeline that consists of retrieving the most relevant chunk spans with hybrid search and reranking, converting the user prompt to a RAG instruction and appending it to the message history, and finally generating the RAG response:
 
 ```python
-from raglite import create_rag_instruction, rag, retrieve_rag_context
+from raglite import add_context, hybrid_search, rag, retrieve_context
 
-# Retrieve relevant chunk spans with hybrid search and reranking
+# Choose a search method
+from dataclasses import replace
+my_config = replace(search_method=hybrid_search)  # Or `vector_search`, `search_and_rerank_chunks`, ...
+
+# Retrieve relevant chunk spans with the configured search method
 user_prompt = "How is intelligence measured?"
-chunk_spans = retrieve_rag_context(query=user_prompt, num_chunks=5, config=my_config)
+chunk_spans = retrieve_context(query=user_prompt, num_chunks=5, config=my_config)
 
 # Append a RAG instruction based on the user prompt and context to the message history
 messages = []  # Or start with an existing message history
-messages.append(create_rag_instruction(user_prompt=user_prompt, context=chunk_spans))
+messages.append(add_context(user_prompt=user_prompt, context=chunk_spans))
 
 # Stream the RAG response and append it to the message history
 stream = rag(messages, config=my_config)
@@ -256,10 +260,10 @@ from raglite import retrieve_chunk_spans
 chunk_spans = retrieve_chunk_spans(chunks_reranked, config=my_config)
 
 # Append a RAG instruction based on the user prompt and context to the message history
-from raglite import create_rag_instruction
+from raglite import add_context
 
 messages = []  # Or start with an existing message history
-messages.append(create_rag_instruction(user_prompt=user_prompt, context=chunk_spans))
+messages.append(add_context(user_prompt=user_prompt, context=chunk_spans))
 
 # Stream the RAG response and append it to the message history
 from raglite import rag

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ from raglite import add_context, hybrid_search, rag, retrieve_context
 
 # Choose a search method
 from dataclasses import replace
-my_config = replace(search_method=hybrid_search)  # Or `vector_search`, `search_and_rerank_chunks`, ...
+my_config = replace(my_config, search_method=hybrid_search)  # Or `vector_search`, `search_and_rerank_chunks`, ...
 
 # Retrieve relevant chunk spans with the configured search method
 user_prompt = "How is intelligence measured?"

--- a/README.md
+++ b/README.md
@@ -196,11 +196,11 @@ The LLM will adaptively decide whether to retrieve information based on the comp
 If you need manual control over the RAG pipeline, you can run a basic but powerful pipeline that consists of retrieving the most relevant chunk spans with hybrid search and reranking, converting the user prompt to a RAG instruction and appending it to the message history, and finally generating the RAG response:
 
 ```python
-from raglite import add_context, hybrid_search, rag, retrieve_context
+from raglite import add_context, rag, retrieve_context, vector_search
 
 # Choose a search method
 from dataclasses import replace
-my_config = replace(my_config, search_method=hybrid_search)  # Or `vector_search`, `search_and_rerank_chunks`, ...
+my_config = replace(my_config, search_method=vector_search)  # Or `hybrid_search`, `search_and_rerank_chunks`, ...
 
 # Retrieve relevant chunk spans with the configured search method
 user_prompt = "How is intelligence measured?"

--- a/src/raglite/__init__.py
+++ b/src/raglite/__init__.py
@@ -4,13 +4,15 @@ from raglite._config import RAGLiteConfig
 from raglite._eval import answer_evals, evaluate, insert_evals
 from raglite._insert import insert_document
 from raglite._query_adapter import update_query_adapter
-from raglite._rag import async_rag, create_rag_instruction, rag, retrieve_rag_context
+from raglite._rag import add_context, async_rag, rag, retrieve_context
 from raglite._search import (
     hybrid_search,
     keyword_search,
     rerank_chunks,
     retrieve_chunk_spans,
     retrieve_chunks,
+    search_and_rerank_chunk_spans,
+    search_and_rerank_chunks,
     vector_search,
 )
 
@@ -26,9 +28,11 @@ __all__ = [
     "retrieve_chunks",
     "retrieve_chunk_spans",
     "rerank_chunks",
+    "search_and_rerank_chunks",
+    "search_and_rerank_chunk_spans",
     # RAG
-    "retrieve_rag_context",
-    "create_rag_instruction",
+    "retrieve_context",
+    "add_context",
     "async_rag",
     "rag",
     # Query adapter

--- a/src/raglite/_config.py
+++ b/src/raglite/_config.py
@@ -11,10 +11,10 @@ from platformdirs import user_data_dir
 from sqlalchemy.engine import URL
 
 from raglite._lazy_llama import llama_supports_gpu_offload
+from raglite._typing import SearchMethod
 
 if TYPE_CHECKING:
     from raglite._database import ChunkSpan
-    from raglite._typing import SearchMethod
 
 # Suppress rerankers output on import until [1] is fixed.
 # [1] https://github.com/AnswerDotAI/rerankers/issues/36

--- a/src/raglite/_config.py
+++ b/src/raglite/_config.py
@@ -66,7 +66,7 @@ class RAGLiteConfig:
     vector_search_multivector: bool = True
     vector_search_query_adapter: bool = True  # Only supported for "cosine" and "dot" metrics.
     # Reranking config.
-    reranker: BaseRanker | tuple[dict[str, BaseRanker], ...] | None = field(
+    reranker: BaseRanker | dict[str, BaseRanker] | None = field(
         default_factory=lambda: {
             "en": FlashRankRanker("ms-marco-MiniLM-L-12-v2", verbose=0, cache_dir=cache_path),
             "other": FlashRankRanker("ms-marco-MultiBERT-L-12", verbose=0, cache_dir=cache_path),

--- a/src/raglite/_mcp.py
+++ b/src/raglite/_mcp.py
@@ -6,7 +6,7 @@ from fastmcp import FastMCP
 from pydantic import Field
 
 from raglite._config import RAGLiteConfig
-from raglite._rag import create_rag_instruction, retrieve_rag_context
+from raglite._rag import add_context, retrieve_context
 
 Query = Annotated[
     str,
@@ -27,14 +27,14 @@ def create_mcp_server(server_name: str, *, config: RAGLiteConfig) -> FastMCP[Any
     @mcp.prompt()
     def kb(query: Query) -> str:
         """Answer a question with information from the knowledge base."""
-        chunk_spans = retrieve_rag_context(query, config=config)
-        rag_instruction = create_rag_instruction(query, chunk_spans)
+        chunk_spans = retrieve_context(query, config=config)
+        rag_instruction = add_context(query, chunk_spans)
         return rag_instruction["content"]
 
     @mcp.tool()
     def search_knowledge_base(query: Query) -> str:
         """Search the knowledge base."""
-        chunk_spans = retrieve_rag_context(query, config=config)
+        chunk_spans = retrieve_context(query, config=config)
         rag_context = '{{"documents": [{elements}]}}'.format(
             elements=", ".join(
                 chunk_span.to_json(index=i + 1) for i, chunk_span in enumerate(chunk_spans)
@@ -44,6 +44,6 @@ def create_mcp_server(server_name: str, *, config: RAGLiteConfig) -> FastMCP[Any
 
     # Warm up the querying pipeline.
     if str(config.db_url).startswith("sqlite") or config.embedder.startswith("llama-cpp-python"):
-        _ = retrieve_rag_context("Hello world", config=config)
+        _ = retrieve_context("Hello world", config=config)
 
     return mcp

--- a/src/raglite/_rag.py
+++ b/src/raglite/_rag.py
@@ -49,6 +49,8 @@ def retrieve_context(
         chunk_spans = retrieve_chunk_spans(results[0], config=config)
     elif all(isinstance(result, Chunk) for result in results):
         chunk_spans = retrieve_chunk_spans(results, config=config)  # type: ignore[arg-type]
+    elif all(isinstance(result, ChunkSpan) for result in results):
+        chunk_spans = results  # type: ignore[assignment]
     return chunk_spans
 
 

--- a/src/raglite/_rag.py
+++ b/src/raglite/_rag.py
@@ -14,47 +14,45 @@ from litellm import (  # type: ignore[attr-defined]
 )
 
 from raglite._config import RAGLiteConfig
-from raglite._database import ChunkSpan
+from raglite._database import Chunk, ChunkSpan
 from raglite._litellm import get_context_size
-from raglite._search import hybrid_search, rerank_chunks, retrieve_chunk_spans
-from raglite._typing import SearchMethod
+from raglite._search import retrieve_chunk_spans
 
 # The default RAG instruction template follows Anthropic's best practices [1].
 # [1] https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/long-context-tips
 RAG_INSTRUCTION_TEMPLATE = """
+---
 You are a friendly and knowledgeable assistant that provides complete and insightful answers.
 Whenever possible, use only the provided context to respond to the question at the end.
 When responding, you MUST NOT reference the existence of the context, directly or indirectly.
 Instead, you MUST treat the context as if its contents are entirely part of your working memory.
+---
 
-<context>{context}</context>
+<context>
+{context}
+</context>
 
 {user_prompt}
 """.strip()
 
 
-def retrieve_rag_context(
-    query: str,
-    *,
-    num_chunks: int = 5,
-    chunk_neighbors: tuple[int, ...] | None = (-1, 1),
-    search: SearchMethod = hybrid_search,
-    config: RAGLiteConfig | None = None,
+def retrieve_context(
+    query: str, *, num_chunks: int = 10, config: RAGLiteConfig | None = None
 ) -> list[ChunkSpan]:
     """Retrieve context for RAG."""
-    # If the user has configured a reranker, we retrieve extra contexts to rerank.
+    # Call the search method.
     config = config or RAGLiteConfig()
-    extra_chunks = 3 * num_chunks if config.reranker else 0
-    # Search for relevant chunks.
-    chunk_ids, _ = search(query, num_results=num_chunks + extra_chunks, config=config)
-    # Rerank the chunks from most to least relevant.
-    chunks = rerank_chunks(query, chunk_ids=chunk_ids, config=config)
-    # Extend the top contexts with their neighbors and group chunks into contiguous segments.
-    context = retrieve_chunk_spans(chunks[:num_chunks], neighbors=chunk_neighbors, config=config)
-    return context
+    results = config.search_method(query, num_results=num_chunks, config=config)
+    # Convert results to chunk spans.
+    chunk_spans = []
+    if isinstance(results, tuple):
+        chunk_spans = retrieve_chunk_spans(results[0], config=config)
+    elif all(isinstance(result, Chunk) for result in results):
+        chunk_spans = retrieve_chunk_spans(results, config=config)  # type: ignore[arg-type]
+    return chunk_spans
 
 
-def create_rag_instruction(
+def add_context(
     user_prompt: str,
     context: list[ChunkSpan],
     *,
@@ -69,10 +67,10 @@ def create_rag_instruction(
     message = {
         "role": "user",
         "content": rag_instruction_template.format(
-            user_prompt=user_prompt.strip(),
             context="\n".join(
                 chunk_span.to_xml(index=i + 1) for i, chunk_span in enumerate(context)
             ),
+            user_prompt=user_prompt.strip(),
         ),
     }
     return message
@@ -145,7 +143,7 @@ def _run_tools(
         if tool_call.function.name == "search_knowledge_base":
             kwargs = json.loads(tool_call.function.arguments)
             kwargs["config"] = config
-            chunk_spans = retrieve_rag_context(**kwargs)
+            chunk_spans = retrieve_context(**kwargs)
             tool_messages.append(
                 {
                     "role": "tool",

--- a/src/raglite/_typing.py
+++ b/src/raglite/_typing.py
@@ -3,14 +3,16 @@
 import io
 import pickle
 from collections.abc import Callable
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 import numpy as np
 from sqlalchemy.engine import Dialect
 from sqlalchemy.sql.operators import Operators
 from sqlalchemy.types import Float, LargeBinary, TypeDecorator, TypeEngine, UserDefinedType
 
-from raglite._config import RAGLiteConfig
+if TYPE_CHECKING:
+    from raglite._config import RAGLiteConfig
+    from raglite._database import Chunk, ChunkSpan
 
 ChunkId = str
 DocumentId = str
@@ -22,10 +24,16 @@ FloatVector = np.ndarray[tuple[int], np.dtype[np.floating[Any]]]
 IntVector = np.ndarray[tuple[int], np.dtype[np.intp]]
 
 
+class BasicSearchMethod(Protocol):
+    def __call__(
+        self, query: str, *, num_results: int, config: "RAGLiteConfig | None" = None
+    ) -> tuple[list[ChunkId], list[float]]: ...
+
+
 class SearchMethod(Protocol):
     def __call__(
-        self, query: str, *, num_results: int = 3, config: RAGLiteConfig | None = None
-    ) -> tuple[list[str], list[float]]: ...
+        self, query: str, *, num_results: int, config: "RAGLiteConfig | None" = None
+    ) -> tuple[list[ChunkId], list[float]] | list["Chunk"] | list["ChunkSpan"]: ...
 
 
 class NumpyArray(TypeDecorator[np.ndarray[Any, np.dtype[np.floating[Any]]]]):

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -4,8 +4,8 @@ import json
 
 from raglite import (
     RAGLiteConfig,
-    create_rag_instruction,
-    retrieve_rag_context,
+    add_context,
+    retrieve_context,
 )
 from raglite._database import ChunkSpan
 from raglite._rag import rag
@@ -15,8 +15,8 @@ def test_rag_manual(raglite_test_config: RAGLiteConfig) -> None:
     """Test Retrieval-Augmented Generation with manual retrieval."""
     # Answer a question with manual RAG.
     user_prompt = "How does Einstein define 'simultaneous events' in his special relativity paper?"
-    chunk_spans = retrieve_rag_context(query=user_prompt, config=raglite_test_config)
-    messages = [create_rag_instruction(user_prompt, context=chunk_spans)]
+    chunk_spans = retrieve_context(query=user_prompt, config=raglite_test_config)
+    messages = [add_context(user_prompt, context=chunk_spans)]
     stream = rag(messages, config=raglite_test_config)
     answer = ""
     for update in stream:

--- a/tests/test_rerank.py
+++ b/tests/test_rerank.py
@@ -25,25 +25,25 @@ def kendall_tau(a: list[T], b: list[T]) -> float:
         pytest.param(None, id="no_reranker"),
         pytest.param(FlashRankRanker("ms-marco-MiniLM-L-12-v2", verbose=0), id="flashrank_english"),
         pytest.param(
-            (
-                ("en", FlashRankRanker("ms-marco-MiniLM-L-12-v2", verbose=0)),
-                ("other", FlashRankRanker("ms-marco-MultiBERT-L-12", verbose=0)),
-            ),
+            {
+                "en": FlashRankRanker("ms-marco-MiniLM-L-12-v2", verbose=0),
+                "other": FlashRankRanker("ms-marco-MultiBERT-L-12", verbose=0),
+            },
             id="flashrank_multilingual",
         ),
     ],
 )
 def reranker(
     request: pytest.FixtureRequest,
-) -> BaseRanker | tuple[tuple[str, BaseRanker], ...] | None:
+) -> BaseRanker | dict[str, BaseRanker] | None:
     """Get a reranker to test RAGLite with."""
-    reranker: BaseRanker | tuple[tuple[str, BaseRanker], ...] | None = request.param
+    reranker: BaseRanker | dict[str, BaseRanker] | None = request.param
     return reranker
 
 
 def test_reranker(
     raglite_test_config: RAGLiteConfig,
-    reranker: BaseRanker | tuple[tuple[str, BaseRanker], ...] | None,
+    reranker: BaseRanker | dict[str, BaseRanker] | None,
 ) -> None:
     """Test inserting a document, updating the indexes, and searching for a query."""
     # Update the config with the reranker.

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -11,7 +11,7 @@ from raglite import (
     vector_search,
 )
 from raglite._database import Chunk, ChunkSpan, Document
-from raglite._typing import SearchMethod
+from raglite._typing import BasicSearchMethod
 
 
 @pytest.fixture(
@@ -23,13 +23,13 @@ from raglite._typing import SearchMethod
 )
 def search_method(
     request: pytest.FixtureRequest,
-) -> SearchMethod:
+) -> BasicSearchMethod:
     """Get a search method to test RAGLite with."""
-    search_method: SearchMethod = request.param
+    search_method: BasicSearchMethod = request.param
     return search_method
 
 
-def test_search(raglite_test_config: RAGLiteConfig, search_method: SearchMethod) -> None:
+def test_search(raglite_test_config: RAGLiteConfig, search_method: BasicSearchMethod) -> None:
     """Test searching for a query."""
     # Search for a query.
     query = "What does it mean for two events to be simultaneous?"
@@ -56,7 +56,9 @@ def test_search(raglite_test_config: RAGLiteConfig, search_method: SearchMethod)
     assert all(isinstance(chunk_span.document, Document) for chunk_span in chunk_spans)
 
 
-def test_search_no_results(raglite_test_config: RAGLiteConfig, search_method: SearchMethod) -> None:
+def test_search_no_results(
+    raglite_test_config: RAGLiteConfig, search_method: BasicSearchMethod
+) -> None:
     """Test searching for a query with no keyword search results."""
     query = "supercalifragilisticexpialidocious"
     num_results = 5
@@ -67,7 +69,7 @@ def test_search_no_results(raglite_test_config: RAGLiteConfig, search_method: Se
     assert all(isinstance(score, float) for score in scores)
 
 
-def test_search_empty_database(llm: str, embedder: str, search_method: SearchMethod) -> None:
+def test_search_empty_database(llm: str, embedder: str, search_method: BasicSearchMethod) -> None:
     """Test searching for a query with an empty database."""
     raglite_test_config = RAGLiteConfig(db_url="sqlite:///:memory:", llm=llm, embedder=embedder)
     query = "supercalifragilisticexpialidocious"


### PR DESCRIPTION
This PR makes the search method and all of its hyperparameters configurable by the user.

Changes:
1. Breaking: change the reranker config from a tuple of (language, reranker) pairs to a dict that maps languages to rerankers.
2. Breaking: rename `retrieve_rag_context` to `retrieve_context`.
3. Breaking: rename `create_rag_instruction` to `add_context` [to the user prompt].
4. Introduce a `BasicSearchMethod` Protocol that returns either `(list[ChunkId], list[float])` or `list[Chunk]`.
5. Introduce a `SearchMethod` Protocol that returns what a `BasicSearchMethod` returns or `list[ChunkSpan]`.
6. Introduce a `search_and_rerank_chunks` function to `_search.py` that searches with a given `BasicSearchMethod` and then reranks the results with the configured reranker.
7. Introduce a `search_and_rerank_chunk_spans` function to `_search.py` that additionally converts to chunk spans.
8. Add a new config option `search_method: SearchMethod` that allows the user to configure their search method of choice. The default is `search_and_rerank_chunk_spans`. The idea is that the user can provide a function that returns chunk spans, thereby wrapping all of the hyperparameters of search (i.e., which `BasicSearchMethod`, the hybrid search hyperparams like oversampling and weights, the reranker config, and the chunk span neighbours).
9. Make the `retrieve_context` function simply call `config.search_method` and convert to chunk spans (if not already the case).
10. Set default weights for hybrid search to 75% for vector and 25% for keyword search.