### PR TITLE
ci: skip slow tests in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ warn_unreachable = true
 [tool.pytest.ini_options]  # https://docs.pytest.org/en/latest/reference/reference.html#ini-options-ref
 addopts = "--color=yes --doctest-modules --ignore=src/raglite/_chainlit.py --exitfirst --failed-first --strict-config --strict-markers --verbosity=2 --junitxml=reports/pytest.xml"
 filterwarnings = ["error", "ignore::DeprecationWarning", "ignore::pytest.PytestUnraisableExceptionWarning"]
+markers = ["slow: mark test as slow"]
 testpaths = ["src", "tests"]
 xfail_strict = true
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,15 @@ from raglite import RAGLiteConfig, insert_document
 POSTGRES_URL = "postgresql+pg8000://raglite_user:raglite_password@postgres:5432/postgres"
 
 
+def pytest_configure(config: pytest.Config) -> None:
+    """Configure pytest to skip slow tests in CI."""
+    if os.environ.get("CI"):
+        markexpr = "not slow"
+        if config.option.markexpr:
+            markexpr = f"({config.option.markexpr}) and ({markexpr})"
+        config.option.markexpr = markexpr
+
+
 def is_postgres_running() -> bool:
     """Check if PostgreSQL is running."""
     try:

--- a/tests/test_chatml_function_calling.py
+++ b/tests/test_chatml_function_calling.py
@@ -73,6 +73,7 @@ def is_accelerator_available() -> bool:
         ),
     ],
 )
+@pytest.mark.slow
 def test_llama_cpp_python_tool_use(
     llm_repo_id: str,
     user_prompt_expected_tool_calls: tuple[str, int],


### PR DESCRIPTION
Changes:
1. Add a slow marker
2. Mark the chatml-function-calling tests as slow
3. Skip slow tests if $CI is set