### PR TITLE
fix: adapt oversampling to chunk size

### DIFF
--- a/src/raglite/_database.py
+++ b/src/raglite/_database.py
@@ -440,7 +440,8 @@ def create_database_engine(config: RAGLiteConfig | None = None) -> Engine:  # no
     ChunkEmbedding.set_embedding_dim(embedding_dim)
     SQLModel.metadata.create_all(engine)
     # Create backend-specific indexes.
-    ef_search = (10 * 4) * 4  # This is (number of results with reranking) * oversampling factor.
+    oversample = round(4 * config.chunk_max_size / RAGLiteConfig.chunk_max_size)
+    ef_search = (10 * 4) * oversample  # This is (# reranked results) * oversampling factor.
     if db_backend == "postgresql":
         # Create a keyword search index with `tsvector` and a vector search index with `pgvector`.
         with Session(engine) as session:

--- a/src/raglite/_search.py
+++ b/src/raglite/_search.py
@@ -47,7 +47,8 @@ def vector_search(
     # chunk embeddings to the query embedding with a single query.
     engine = create_database_engine(config)
     with Session(engine) as session:
-        num_hits = oversample * max(num_results, 10)
+        corrected_oversample = oversample * config.chunk_max_size / RAGLiteConfig.chunk_max_size
+        num_hits = round(corrected_oversample) * max(num_results, 10)
         dist = ChunkEmbedding.embedding.distance(  # type: ignore[attr-defined]
             query_embedding, metric=config.vector_search_index_metric
         ).label("dist")
@@ -139,7 +140,7 @@ def hybrid_search(  # noqa: PLR0913
     query: str,
     *,
     num_results: int = 3,
-    oversample: int = 4,
+    oversample: int = 2,
     vector_search_weight: float = 0.75,
     keyword_search_weight: float = 0.25,
     config: RAGLiteConfig | None = None,


### PR DESCRIPTION
The oversampling in `vector_search` depends on the number of chunklets in the chunk, which itself depends on the chunk size. This PR adapts the oversampling factor as a function of the configured chunk size.