### PR TITLE
fix: upgrade rerankers and recommended Cohere model

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ from rerankers import Reranker
 # Example remote API-based reranker:
 my_config = RAGLiteConfig(
     db_url="postgresql://my_username:my_password@my_host:5432/my_database"
-    reranker=Reranker("rerank-v3.5", api_provider="cohere", api_key=COHERE_API_KEY)  # Multilingual
+    reranker=Reranker("rerank-v3.5", model_type="cohere", api_key=COHERE_API_KEY)  # Multilingual
 )
 
 # Example local cross-encoder reranker per language (this is the default):

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ from rerankers import Reranker
 # Example remote API-based reranker:
 my_config = RAGLiteConfig(
     db_url="postgresql://my_username:my_password@my_host:5432/my_database"
-    reranker=Reranker("cohere", lang="en", api_key=COHERE_API_KEY)
+    reranker=Reranker("rerank-v3.5", api_provider="cohere", api_key=COHERE_API_KEY)  # Multilingual
 )
 
 # Example local cross-encoder reranker per language (this is the default):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "pydantic (>=2.7.0)",
   # Reranking:
   "langdetect (>=1.0.9)",
-  "rerankers[flashrank] (>=0.6.0)",
+  "rerankers[api,flashrank] (>=0.10.0)",
   # Storage:
   "duckdb (>=1.1.3)",
   "duckdb-engine (>=0.16.0)",


### PR DESCRIPTION
Changes:
1. Increase minimum version of Rerankers to v0.10.0, which [fixes an issue with API rerankers](https://github.com/AnswerDotAI/rerankers/pull/65).
2. Upgrade recommended Cohere model to v3.5, which performs significantly better than 3.0 and is multilingual.