### PR TITLE
feat: add ability to control the gap in query adapter

### DIFF
--- a/src/raglite/_config.py
+++ b/src/raglite/_config.py
@@ -60,7 +60,7 @@ class RAGLiteConfig:
     # Chunk config used to partition documents into chunks.
     chunk_max_size: int = 2048  # Max number of characters per chunk.
     # Vector search config.
-    vector_search_index_metric: Literal["cosine", "dot", "l2"] = "cosine"
+    vector_search_distance_metric: Literal["cosine", "dot", "l2"] = "cosine"
     vector_search_multivector: bool = True
     vector_search_query_adapter: bool = True  # Only supported for "cosine" and "dot" metrics.
     # Reranking config.

--- a/src/raglite/_database.py
+++ b/src/raglite/_database.py
@@ -455,7 +455,7 @@ def create_database_engine(config: RAGLiteConfig | None = None) -> Engine:  # no
                 CREATE INDEX IF NOT EXISTS vector_search_chunk_index ON chunk_embedding
                 USING hnsw (
                     (embedding::halfvec({embedding_dim}))
-                    halfvec_{metrics[config.vector_search_index_metric]}_ops
+                    halfvec_{metrics[config.vector_search_distance_metric]}_ops
                 );
                 SET hnsw.ef_search = {ef_search};
             """
@@ -505,7 +505,7 @@ def create_database_engine(config: RAGLiteConfig | None = None) -> Engine:  # no
                     CREATE INDEX vector_search_chunk_index
                     ON chunk_embedding
                     USING HNSW (embedding)
-                    WITH (metric = '{metrics[config.vector_search_index_metric]}');
+                    WITH (metric = '{metrics[config.vector_search_distance_metric]}');
                 """
                 session.execute(text(create_vector_index_sql))
             session.commit()

--- a/src/raglite/_search.py
+++ b/src/raglite/_search.py
@@ -50,7 +50,7 @@ def vector_search(
         corrected_oversample = oversample * config.chunk_max_size / RAGLiteConfig.chunk_max_size
         num_hits = round(corrected_oversample) * max(num_results, 10)
         dist = ChunkEmbedding.embedding.distance(  # type: ignore[attr-defined]
-            query_embedding, metric=config.vector_search_index_metric
+            query_embedding, metric=config.vector_search_distance_metric
         ).label("dist")
         sim = (1.0 - dist).label("sim")
         top_vectors = select(ChunkEmbedding.chunk_id, sim).order_by(dist).limit(num_hits).subquery()


### PR DESCRIPTION
Changes:
1. Expand the query adapter docstring.
2. Return the query adapter itself instead of returning None. Could be useful for some users.
3. Expose control over the strength of the query adapter in the form of a `optimize_gap` kwarg. This is a number between 0 and 1, where 0 means no query adaptation and 1 means maximum query adaptation. The default is 5% because we want to correct just enough to correct incorrectly ranked results, but not affect correctly ranked results.
4. Allow the algorithm to fetch more evals if they are available, but not more than necessary.
5. BREAKING: Rename `config.vector_search_index_metric` to a more accurate and explicit `config.vector_search_distance_metric`.