### PR TITLE
feat: optimally separate result sets in query adapter

### DIFF
--- a/src/raglite/_query_adapter.py
+++ b/src/raglite/_query_adapter.py
@@ -23,7 +23,7 @@ def _optimize_query_target(
     P: FloatMatrix,  # noqa: N803,
     N: FloatMatrix,  # noqa: N803,
     *,
-    α: float = 0.15,  # noqa: PLC2401
+    α: float = 0.05,  # noqa: PLC2401
 ) -> FloatVector:
     # Convert to double precision for the optimizer.
     q_dtype = q.dtype
@@ -42,7 +42,7 @@ def update_query_adapter(  # noqa: PLR0915
     *,
     max_evals: int = 4096,
     optimize_top_k: int = 40,
-    optimize_gap: float = 0.15,
+    optimize_gap: float = 0.05,
     config: RAGLiteConfig | None = None,
 ) -> FloatMatrix:
     """Compute an optimal query adapter and update the database with it.

--- a/src/raglite/_query_adapter.py
+++ b/src/raglite/_query_adapter.py
@@ -89,9 +89,9 @@ def update_query_adapter(  # noqa: PLR0915
     vector t* for the query embedding qᵢ as follows:
 
     t* := argmax ½ ||t - qᵢ||²
-             s.t. Dᵢ t >= 0
+            s.t. Dᵢ t >= 0
 
-    where the constraint matrix Dᵢ := [pₘᵀ - (1 + α) * nₙᵀ]ₘₙ comprises all pairs of positive and
+    where the constraint matrix Dᵢ := [pₘᵀ - (1 + α) nₙᵀ]ₘₙ comprises all pairs of positive and
     negative chunk embeddings in the result set corresponding to the query embedding qᵢ. This
     optimisation problem expresses the idea that the target vector t* should be as close as
     possible to the query embedding qᵢ, while separating all positive and negative chunk embeddings

--- a/tests/test_query_adapter.py
+++ b/tests/test_query_adapter.py
@@ -1,0 +1,40 @@
+"""Test RAGLite's query adapter."""
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from raglite import RAGLiteConfig, insert_evals, update_query_adapter, vector_search
+from raglite._database import IndexMetadata
+
+
+@pytest.mark.slow
+def test_query_adapter(raglite_test_config: RAGLiteConfig) -> None:
+    """Test the query adapter update functionality."""
+    # Create a config with and without the query adapter enabled.
+    config_with_query_adapter = replace(raglite_test_config, vector_search_query_adapter=True)
+    config_without_query_adapter = replace(raglite_test_config, vector_search_query_adapter=False)
+    # Verify that there is no query adapter in the database.
+    Q = IndexMetadata.get("default", config=config_without_query_adapter).get("query_adapter")  # noqa: N806
+    assert Q is None
+    # Insert evals.
+    insert_evals(num_evals=2, max_contexts_per_eval=10, config=config_with_query_adapter)
+    # Update the query adapter.
+    A = update_query_adapter(config=config_with_query_adapter)  # noqa: N806
+    assert isinstance(A, np.ndarray)
+    assert A.ndim == 2  # noqa: PLR2004
+    assert A.shape[0] == A.shape[1]
+    assert np.isfinite(A).all()
+    # Verify that there is a query adapter in the database.
+    Q = IndexMetadata.get("default", config=config_without_query_adapter).get("query_adapter")  # noqa: N806
+    assert isinstance(Q, np.ndarray)
+    assert Q.ndim == 2  # noqa: PLR2004
+    assert Q.shape[0] == Q.shape[1]
+    assert np.isfinite(Q).all()
+    assert np.all(A == Q)
+    # Verify that the query adapter affects the results of vector search.
+    query = "How does Einstein define 'simultaneous events' in his special relativity paper?"
+    _, scores_qa = vector_search(query, config=config_with_query_adapter)
+    _, scores_no_qa = vector_search(query, config=config_without_query_adapter)
+    assert scores_qa != scores_no_qa


### PR DESCRIPTION
Changes:
1. Use `dataclasses.replace` to set `config.vector_search_query_adapter` to `False` in `update_query_adapter`.
2. Remove the `max_triplets_per_eval` option.
3. Add a passthrough component to the query adapter so that does not affect queries that are not covered by the evals. At the same time, this makes it possible to update the query adapter with only a single eval.
4. Build the query adapter from only a single rank-one update per eval. This reduces the size of the query adapter and has the benefit that all evals contribute (approximately) equally to the query adapter.
5. Optimize the rank-one update per eval to optimally separate positive from negative chunks using a new constrained least squares problem. The solution to this problem simultaneously (a) minimises the impact of the query adapter on the query vector, and (b) pushes all positive chunks above all negative chunks for a given eval.
6. Fix a scaling issue of the query adapter for `config.vector_search_distance_metric == "dot"`.
7. Clear the index metadata cache after updating the query adapter so it gets picked up automatically in the next `vector_search` call.
8. Add tests for the query adapter.