### PR TITLE
fix: fix parsing of font sizes for pdfs with no headings

### DIFF
--- a/src/raglite/_markdown.py
+++ b/src/raglite/_markdown.py
@@ -73,7 +73,7 @@ def parsed_pdf_to_markdown(pages: list[dict[str, Any]]) -> list[str]:  # noqa: C
                         elif span_font_size == mode_font_size or len(heading_font_sizes) == 0:
                             idx = 6
                         else:
-                            idx = np.argmin(np.abs(heading_font_sizes - span_font_size)) # type: ignore[assignment]
+                            idx = np.argmin(np.abs(heading_font_sizes - span_font_size))  # type: ignore[assignment]
                         span["md"]["heading_level"] = idx + 1
                         heading_level[idx] += len(span["text"])
                     line["md"]["heading_level"] = np.argmax(heading_level) + 1


### PR DESCRIPTION
Based on https://github.com/superlinear-ai/raglite/issues/88

Takes what matters to fix it.

Running
```
from pathlib import Path

from _configure import configure
from raglite import Document, insert_documents

config = configure()
documents = [
    Document.from_path(Path("/workspaces/raglite_benchmark/src/raglite_benchmark/groovy.pdf")),
]
insert_documents(documents, config=config)
```

Failed with

```
Traceback (most recent call last):
  File "/workspaces/raglite_benchmark/src/raglite_benchmark/test_issue.py", line 8, in <module>
    Document.from_path(Path("/workspaces/raglite_benchmark/src/raglite_benchmark/groovy.pdf")),
  File "/opt/raglite/src/raglite/_database.py", line 126, in from_path
    content=document_to_markdown(doc_path),
  File "/opt/raglite/src/raglite/_markdown.py", line 203, in document_to_markdown
    doc = "\n\n".join(parsed_pdf_to_markdown(pages))
  File "/opt/raglite/src/raglite/_markdown.py", line 185, in parsed_pdf_to_markdown
    pages = add_heading_level_metadata(pages)
  File "/opt/raglite/src/raglite/_markdown.py", line 76, in add_heading_level_metadata
    idx = np.argmin(np.abs(heading_font_sizes - span_font_size))  # type: ignore[assignment]
  File "/opt/venv/lib/python3.10/site-packages/numpy/core/fromnumeric.py", line 1325, in argmin
    return _wrapfunc(a, 'argmin', axis=axis, out=out, **kwds)
  File "/opt/venv/lib/python3.10/site-packages/numpy/core/fromnumeric.py", line 59, in _wrapfunc
    return bound(*args, **kwds)
ValueError: attempt to get argmin of an empty sequence
```