### PR TITLE
feat: add metadata filtering

### DIFF
--- a/src/raglite/_config.py
+++ b/src/raglite/_config.py
@@ -26,11 +26,17 @@ cache_path = Path(user_data_dir("raglite", ensure_exists=True))
 # Lazily load the default search method to avoid circular imports.
 # TODO: Replace with search_and_rerank_chunk_spans after benchmarking.
 def _vector_search(
-    query: str, *, num_results: int = 8, config: "RAGLiteConfig | None" = None
+    query: str,
+    *,
+    num_results: int = 8,
+    metadata_filter: dict[str, str] | None = None,
+    config: "RAGLiteConfig | None" = None,
 ) -> tuple[list[ChunkId], list[float]]:
     from raglite._search import vector_search
 
-    return vector_search(query, num_results=num_results, config=config)
+    return vector_search(
+        query, num_results=num_results, metadata_filter=metadata_filter, config=config
+    )
 
 
 @dataclass(frozen=True)

--- a/src/raglite/_rag.py
+++ b/src/raglite/_rag.py
@@ -37,12 +37,18 @@ Instead, you MUST treat the context as if its contents are entirely part of your
 
 
 def retrieve_context(
-    query: str, *, num_chunks: int = 10, config: RAGLiteConfig | None = None
+    query: str,
+    *,
+    num_chunks: int = 10,
+    metadata_filter: dict[str, str] | None = None,
+    config: RAGLiteConfig | None = None,
 ) -> list[ChunkSpan]:
     """Retrieve context for RAG."""
     # Call the search method.
     config = config or RAGLiteConfig()
-    results = config.search_method(query, num_results=num_chunks, config=config)
+    results = config.search_method(
+        query, num_results=num_chunks, metadata_filter=metadata_filter, config=config
+    )
     # Convert results to chunk spans.
     chunk_spans = []
     if isinstance(results, tuple):
@@ -119,6 +125,14 @@ def _get_tools(
                                     "The `query` string MUST be a precise single-faceted question in the user's language.\n"
                                     "The `query` string MUST resolve all pronouns to explicit nouns."
                                 ),
+                            },
+                            "metadata_filter": {
+                                "type": "object",
+                                "description": (
+                                    "Optional metadata filter to restrict search to documents with specific metadata key-value pairs.\n"
+                                    'Example: {"user_id": "123", "category": "public"}'
+                                ),
+                                "additionalProperties": {"type": "string"},
                             },
                         },
                         "required": ["query"],

--- a/src/raglite/_typing.py
+++ b/src/raglite/_typing.py
@@ -31,13 +31,23 @@ IntVector = np.ndarray[tuple[int], np.dtype[np.intp]]
 
 class BasicSearchMethod(Protocol):
     def __call__(
-        self, query: str, *, num_results: int, config: "RAGLiteConfig | None" = None
+        self,
+        query: str,
+        *,
+        num_results: int,
+        metadata_filter: dict[str, str] | None = None,
+        config: "RAGLiteConfig | None" = None,
     ) -> tuple[list[ChunkId], list[float]]: ...
 
 
 class SearchMethod(Protocol):
     def __call__(
-        self, query: str, *, num_results: int, config: "RAGLiteConfig | None" = None
+        self,
+        query: str,
+        *,
+        num_results: int,
+        metadata_filter: dict[str, str] | None = None,
+        config: "RAGLiteConfig | None" = None,
     ) -> tuple[list[ChunkId], list[float]] | list["Chunk"] | list["ChunkSpan"]: ...
 
 

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -3,8 +3,10 @@
 import json
 
 from raglite import (
+    Document,
     RAGLiteConfig,
     add_context,
+    insert_documents,
     retrieve_context,
 )
 from raglite._database import ChunkSpan
@@ -60,3 +62,26 @@ def test_rag_auto_without_retrieval(raglite_test_config: RAGLiteConfig) -> None:
     # Verify that no RAG context was retrieved.
     assert [message["role"] for message in messages] == ["user", "assistant"]
     assert not chunk_spans
+
+
+def test_retrieve_context_with_metadata_filter(raglite_test_config: RAGLiteConfig) -> None:
+    """Test retrieving context with metadata filtering."""
+    # Insert test documents with metadata.
+    test_docs = [
+        Document.from_text("Python guide", filename="python.md", metadata={"user_id": "user_123"}),
+        Document.from_text("JavaScript guide", filename="js.md", metadata={"user_id": "user_456"}),
+    ]
+    insert_documents(test_docs, config=raglite_test_config)
+    # Test retrieve_context with metadata filter.
+    filtered_context = retrieve_context(
+        query="guide",
+        num_chunks=2,
+        metadata_filter={"user_id": "user_123"},
+        config=raglite_test_config,
+    )
+    assert all(isinstance(chunk_span, ChunkSpan) for chunk_span in filtered_context)
+    # Verify that filtered context only includes chunks from the specified user.
+    for chunk_span in filtered_context:
+        for chunk in chunk_span.chunks:
+            if "user_id" in chunk.metadata_:
+                assert chunk.metadata_["user_id"] == "user_123"


### PR DESCRIPTION
This PR adds metadata filtering for RAGLite

It supports

## What's new
- Metadata is converted to `JSONB` when used with a Postgres DB. When used with DuckDB, it's stored as plain `JSON`.
- All search functions (keyword, vector, hybrid) accept metadata filtering. 

Currently only string key-value pairs are recommended to use as metadata. They can be defined like so: 
 
```python
# Option 1  
Document.from_text(
      "Python is great for data science and machine learning.",
      filename="python_guide.md",
      user_id="alice",
      category="programming",
  ),

# Option 2
metadata = {"user_id":"alice", "category":"programming"}
 Document.from_text(
      content=content,
      filename=filename,
      **metadata, 
  )
```

## Known Issues 
There is no validation of the metadata format. It should be added as string key-value pairs, but this is not enforced. 

When doing this: 
```python
metadata = {"user_id":"alice", "category":"programming"}
 Document.from_text(
      content=content,
      filename=filename,
      metadata=metadata, 
  )
```
we obtain something like this: 
```json
"metadata": {
    "filename": "docker_guide.md",
    "url": null,
    "uri": null,
    "size": 50,
    "metadata": {
        "user_id": "alice",
        "category": "devops"
    }
```
on which filtering for user_id still works, as it evaluates also nested dictionary objects (which may not be what we want).  

---
addresses [[metadata] v1 - Add user filtering](https://github.com/orgs/superlinear-ai/projects/10?pane=issue&itemId=96232107)
