### PR TITLE
feat: Add metadata generation callbacks for documents and chunks

### DIFF
--- a/src/raglite/_config.py
+++ b/src/raglite/_config.py
@@ -11,7 +11,7 @@ from platformdirs import user_data_dir
 from sqlalchemy.engine import URL
 
 from raglite._lazy_llama import llama_supports_gpu_offload
-from raglite._typing import ChunkId, SearchMethod
+from raglite._typing import ChunkId, ChunkMetadataFunction, DocumentMetadataFunction, SearchMethod
 
 # Suppress rerankers output on import until [1] is fixed.
 # [1] https://github.com/AnswerDotAI/rerankers/issues/36
@@ -74,3 +74,11 @@ class RAGLiteConfig:
     # Search config: you can pick any search method that returns (list[ChunkId], list[float]),
     # list[Chunk], or list[ChunkSpan].
     search_method: SearchMethod = field(default=_vector_search, compare=False)
+    # Function applied at document loading that outputs
+    # a dictionary of metadata tags to be added to the document.
+    # Takes (content: str, metadata: dict[str, str]) -> dict[str, str].
+    document_metadata_function: DocumentMetadataFunction | None = None
+    # Function applied on chunks after they have been built that
+    # outputs a dictionary of metadata tags to be added to the chunk.
+    # Takes (content: str, metadata: dict[str, str]) -> dict[str, str].
+    chunk_metadata_function: ChunkMetadataFunction | None = None

--- a/src/raglite/_typing.py
+++ b/src/raglite/_typing.py
@@ -41,6 +41,40 @@ class SearchMethod(Protocol):
     ) -> tuple[list[ChunkId], list[float]] | list["Chunk"] | list["ChunkSpan"]: ...
 
 
+class DocumentMetadataFunction(Protocol):
+    """Function that processes document content and existing metadata and returns new metadata tags.
+
+    Args:
+        content: The full document content as string
+        metadata: Document metadata dictionary
+
+    Returns
+    -------
+        Dictionary of metadata tags to add to the document
+    """
+
+    def __call__(
+        self, content: str | None, metadata: dict[str, str] | None
+    ) -> dict[str, str]: ...
+
+
+class ChunkMetadataFunction(Protocol):
+    """Function that processes chunk content and existing metadata and returns new metadata tags.
+
+    Args:
+        content: The chunk content as string
+        metadata: Chunk metadata dictionary
+
+    Returns
+    -------
+        Dictionary of metadata tags to add to the chunk
+    """
+
+    def __call__(
+        self, content: str | None, metadata: dict[str, str] | None
+    ) -> dict[str, str]: ...
+
+
 class NumpyArray(TypeDecorator[np.ndarray[Any, np.dtype[np.floating[Any]]]]):
     """A NumPy array column type for SQLAlchemy."""
 


### PR DESCRIPTION
This PR adds two optional callback functions (`document_metadata_function` and `chunk_metadata_function`) that allow users to implement custom metadata generation. Users can define their own functions following the signature `(content: str, metadata: dict[str, str]) -> dict[str, str]` to dynamically add metadata tags to documents during loading or to individual chunks after creation. Both callbacks default to `None` and are applied via `dict.update()` to merge generated metadata with existing metadata.

Probably we should wait with this PR until we have #160 merged