### PR TITLE
feat: add parallel tool execution

### DIFF
--- a/src/raglite/_rag.py
+++ b/src/raglite/_rag.py
@@ -125,7 +125,7 @@ def _get_token_counts(items: Sequence[str | ChunkSpan | Mapping[str, str]]) -> l
 
 
 def _limit_chunkspans(
-    tool_chunk_spans: tuple[str, list[ChunkSpan]],
+    tool_chunk_spans: dict[str, list[ChunkSpan]],
     config: RAGLiteConfig,
     *,
     messages: list[dict[str, str]] | None = None,
@@ -319,10 +319,7 @@ def _run_tools(
     # 1. Parallel Execution
     # We use the _run_tool helper to fetch data concurrently
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
-        futures = [
-            executor.submit(_run_tool, tool_call, config)
-            for tool_call in tool_calls
-        ]
+        futures = [executor.submit(_run_tool, tool_call, config) for tool_call in tool_calls]
 
         # Collect results as they finish
         try:


### PR DESCRIPTION
## Pull Request Overview

This pull request introduces parallel execution for tool calls in the RAG pipeline to improve performance when multiple tools are invoked simultaneously. The refactoring splits the tool execution logic into separate functions and leverages Python's `ThreadPoolExecutor` for concurrent processing.

**Key changes:**
- Refactored monolithic `_run_tools` function into `_run_tool` (single execution) and `_run_tools` (parallel orchestration)
- Implemented parallel tool execution using `ThreadPoolExecutor` with configurable worker count