### PR TITLE
chore: update mypy to ignore unused ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ show_column_numbers = true
 show_error_codes = true
 show_error_context = true
 warn_unreachable = true
+warn_unused_ignores = false
 
 [tool.pytest.ini_options]  # https://docs.pytest.org/en/latest/reference/reference.html#ini-options-ref
 addopts = "--color=yes --doctest-modules --ignore=src/raglite/_chainlit.py --exitfirst --failed-first --strict-config --strict-markers --verbosity=2 --junitxml=reports/pytest.xml"


### PR DESCRIPTION
LiteLLM, RAGAs and Chainlit have in newer versions fixed some typing issues. Because of this some type: ignore comments we have are unused, causing a mypy error.

We would still like to support older versions of those packages, hence I set mypy to not flag unused type: ignore comments.