### PR TITLE
feat: Update Qwen3 to Qwen3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ my_config = RAGLiteConfig(
 # Example 'local' config with a DuckDB database and a llama.cpp LLM:
 my_config = RAGLiteConfig(
     db_url="duckdb:///raglite.db",
-    llm="llama-cpp-python/unsloth/Qwen3-8B-GGUF/*Q4_K_M.gguf@8192",
+    llm="llama-cpp-python/unsloth/Qwen3.5-9B-GGUF/*Q4_K_M.gguf@8192",
     embedder="llama-cpp-python/lm-kit/bge-m3-gguf/*F16.gguf@512", # More than 512 tokens degrades bge-m3's performance
 )
 ```
@@ -377,7 +377,7 @@ RAGLite comes with an [MCP server](https://modelcontextprotocol.io) implemented 
 ```
 raglite \
     --db-url duckdb:///raglite.db \
-    --llm llama-cpp-python/unsloth/Qwen3-4B-GGUF/*Q4_K_M.gguf@8192 \
+    --llm llama-cpp-python/unsloth/Qwen3.5-4B-GGUF/*Q4_K_M.gguf@8192 \
     --embedder llama-cpp-python/lm-kit/bge-m3-gguf/*F16.gguf@512 \
     mcp install
 ```
@@ -413,7 +413,7 @@ You can specify the database URL, LLM, and embedder directly in the Chainlit fro
 ```sh
 raglite \
     --db-url duckdb:///raglite.db \
-    --llm llama-cpp-python/unsloth/Qwen3-4B-GGUF/*Q4_K_M.gguf@8192 \
+    --llm llama-cpp-python/unsloth/Qwen3.5-4B-GGUF/*Q4_K_M.gguf@8192 \
     --embedder llama-cpp-python/lm-kit/bge-m3-gguf/*F16.gguf@512 \
     chainlit
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ dev = [
 # Frontend:
 chainlit = ["chainlit (>=2.0.0)"]
 # Large Language Models:
-llama-cpp-python = ["llama-cpp-python (>=0.3.9)"]
+llama-cpp-python = ["llama-cpp-python (>=0.3.16)"]  # Qwen 3.5 support
 # Markdown conversion:
 mistral-ocr = ["mistralai (>=1.10.1)"]
 pandoc = ["pypandoc-binary (>=1.13)"]

--- a/src/raglite/_config.py
+++ b/src/raglite/_config.py
@@ -68,9 +68,9 @@ class RAGLiteConfig:
     # LLM config used for generation.
     llm: str = field(
         default_factory=lambda: (
-            "llama-cpp-python/unsloth/Qwen3-8B-GGUF/*Q4_K_M.gguf@8192"
+            "llama-cpp-python/unsloth/Qwen3.5-9B-GGUF/*Q4_K_M.gguf@8192"
             if llama_supports_gpu_offload()
-            else "llama-cpp-python/unsloth/Qwen3-4B-GGUF/*Q4_K_M.gguf@8192"
+            else "llama-cpp-python/unsloth/Qwen3.5-4B-GGUF/*Q4_K_M.gguf@8192"
         )
     )
     llm_max_tries: int = 4

--- a/src/raglite/_litellm.py
+++ b/src/raglite/_litellm.py
@@ -55,7 +55,7 @@ class LlamaCppPythonLLM(CustomLLM):
     from litellm import completion
 
     response = completion(
-        model="llama-cpp-python/unsloth/Qwen3-8B-GGUF/*Q4_K_M.gguf@8192",
+        model="llama-cpp-python/unsloth/Qwen3.5-9B-GGUF/*Q4_K_M.gguf@8192",
         messages=[{"role": "user", "content": "Hello world!"}],
         # stream=True
     )

--- a/src/raglite/_rag.py
+++ b/src/raglite/_rag.py
@@ -152,6 +152,14 @@ def _limit_chunkspans(
     # Early exit if we're already under the limit
     if total_tokens <= max_tokens:
         return tool_chunk_spans
+    # If the context window is completely exhausted, return empty spans.
+    if max_tokens <= 0 or total_tokens == 0:
+        logger.warning(
+            "RAG context was limited to 0 out of %d chunks due to context window size. "
+            "Consider using a model with a bigger context window or reducing the number of retrieved chunks.",
+            total_chunk_spans,
+        )
+        return {tool_id: [] for tool_id in tool_chunk_spans}
     # Allocate tokens proportionally and truncate
     new_total_chunk_spans = 0
     scale_ratio = max_tokens / total_tokens

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,10 +83,10 @@ def database(request: pytest.FixtureRequest) -> str:
     params=[
         pytest.param(
             (
-                "llama-cpp-python/unsloth/Qwen3-4B-GGUF/*Q4_K_M.gguf@8192",  # mistralai/Ministral-3-3B-Instruct-2512
+                "llama-cpp-python/unsloth/Qwen3.5-4B-GGUF/*Q4_K_M.gguf@6144",  # 8192 exceeds Metal GPU memory when embedding model is co-loaded.
                 "llama-cpp-python/lm-kit/bge-m3-gguf/*Q4_K_M.gguf@512",  # More context degrades performance.
             ),
-            id="qwen3_4B-bge_m3",
+            id="qwen3.5_4B-bge_m3",
         ),
         pytest.param(
             ("gpt-4o-mini", "text-embedding-3-small"),

--- a/tests/test_chatml_function_calling.py
+++ b/tests/test_chatml_function_calling.py
@@ -63,10 +63,10 @@ def is_accelerator_available() -> bool:
 @pytest.mark.parametrize(
     "llm_repo_id",
     [
-        pytest.param("unsloth/Qwen3-4B-GGUF", id="qwen3_4B"),
+        pytest.param("unsloth/Qwen3.5-4B-GGUF", id="qwen3.5_4B"),
         pytest.param(
-            "unsloth/Qwen3-8B-GGUF",
-            id="qwen3_8B",
+            "unsloth/Qwen3.5-9B-GGUF",
+            id="qwen3.5_9B",
             marks=pytest.mark.skipif(
                 not is_accelerator_available(), reason="Accelerator not available"
             ),


### PR DESCRIPTION
## Summary

- Upgrade default local LLM from Qwen 3 (8B/4B) to Qwen 3.5 (9B/4B)
- Bump llama-cpp-python optional dep from >=0.3.9 to >=0.3.16
- Fix division by zero in `_limit_chunkspans` when context budget is exhausted

## Blocker

Depends on [abetlen/llama-cpp-python#2133](https://github.com/abetlen/llama-cpp-python/pull/2133), which adds Qwen 3.5 GDN (Gated Delta Network) support to llama-cpp-python. That PR also fixes a prefix-caching bug affecting all hybrid architecture models. Until it is merged and released as >=0.3.16, this PR cannot be merged.

## Known issue

`test_self_query` fails: Qwen 3.5 returns `{'topic': ['Physics']}` instead of `{}` for an off-topic query ("What is the price of a Bugatti Chiron?"). The model applies a metadata filter even when the query is unrelated to the dataset. This is a behavioral regression compared to Qwen 3 and should be addressed separately, either by tuning the self-query prompt or by accepting the looser behavior.

## Test notes

- Tests use n_ctx=6144 instead of the default 8192 because the GDN model plus the embedding model together exceed Metal GPU memory at 8192
- All other non-slow tests pass (31 passed, 1 pre-existing OpenAI API failure unrelated to this change)
- All slow function-calling tests pass (16 passed, 2 skipped for PostgreSQL)
