### PR TITLE
fix: narrow Python support and remove Mistral extra

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,6 +68,7 @@ repos:
         types_or: [python, pyi]
       - id: mypy
         name: mypy
-        entry: mypy
+        entry: mypy src tests
         language: system
+        pass_filenames: false
         types: [python]

--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ The following development environments are supported:
 
 - This project follows the [Conventional Commits](https://www.conventionalcommits.org/) standard to automate [Semantic Versioning](https://semver.org/) and [Keep A Changelog](https://keepachangelog.com/) with [Commitizen](https://github.com/commitizen-tools/commitizen).
 - Run `poe` from within the development environment to print a list of [Poe the Poet](https://github.com/nat-n/poethepoet) tasks available to run on this project.
-- Run `uv add {package}` from within the development environment to install a run time dependency and add it to `pyproject.toml` and `uv.lock`. Add `--dev` to install a development dependency.
+- Run `uv add {package}` from within the development environment to install a run time dependency and add it to `pyproject.toml`. Add `--dev` to install a development dependency.
 - Run `uv sync --upgrade` from within the development environment to upgrade all dependencies to the latest versions allowed by `pyproject.toml`. Add `--only-dev` to upgrade the development dependencies only.
 - Run `cz bump` to bump the package's version, update the `CHANGELOG.md`, and create a git tag. Then push the changes and the git tag with `git push origin main --tags`.
 

--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ To add support for filetypes other than PDF, use the `pandoc` extra:
 pip install raglite[pandoc]
 ```
 
-To add support for high-quality document processing with [Mistral OCR](https://docs.mistral.ai/capabilities/document/), use the `mistral-ocr` extra:
+To add support for high-quality document processing with [Mistral OCR](https://docs.mistral.ai/capabilities/document/), install `mistralai`:
 
 ```sh
-pip install raglite[mistral-ocr]
+pip install mistralai
 ```
 
 To add support for evaluation, use the `ragas` extra:
@@ -160,7 +160,7 @@ my_config = RAGLiteConfig(
 > ✍️ To insert documents other than PDF, install the `pandoc` extra with `pip install raglite[pandoc]`.
 
 > [!TIP]
-> 🔎 For higher-quality document processing with automatic image descriptions, install the `mistral-ocr` extra with `pip install raglite[mistral-ocr]` and configure it as follows:
+> 🔎 For higher-quality document processing with automatic image descriptions, install `mistralai` and configure it as follows:
 > ```python
 > from raglite import RAGLiteConfig, MistralOCRConfig
 >

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dev = [
   "ipykernel (>=6.29.4)",
   "ipython (>=8.18.0)",
   "ipywidgets (>=8.1.2)",
-  "mypy (>=1.18.2,!=2.1.0)",
+  "mypy (>=1.18.2)",
   "pdoc (>=15.0.1)",
   "poethepoet (>=0.32.1)",
   "pre-commit (>=4.0.1)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 authors = [
   { name = "Laurent Sorber", email = "laurent@superlinear.eu" },
 ]
-requires-python = ">=3.10,<4.0"
+requires-python = ">=3.10,<3.14"
 dependencies = [
   # Configuration:
   "platformdirs (>=4.0.0)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ chainlit = ["chainlit (>=2.0.0)"]
 llama-cpp-python = ["llama-cpp-python (>=0.3.9)"]
 # Markdown conversion:
 pandoc = ["pypandoc-binary (>=1.13)"]
+mistral-ocr = []
 # Evaluation:
 ragas = ["pandas (>=2.1.1)", "ragas (>=0.3.3)"]
 # Benchmarking:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dev = [
   "ipykernel (>=6.29.4)",
   "ipython (>=8.18.0)",
   "ipywidgets (>=8.1.2)",
-  "mypy (>=1.18.2)",
+  "mypy (>=1.18.2,!=2.1.0)",
   "pdoc (>=15.0.1)",
   "poethepoet (>=0.32.1)",
   "pre-commit (>=4.0.1)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,6 @@ chainlit = ["chainlit (>=2.0.0)"]
 # Large Language Models:
 llama-cpp-python = ["llama-cpp-python (>=0.3.9)"]
 # Markdown conversion:
-mistral-ocr = ["mistralai (>=1.10.1)"]
 pandoc = ["pypandoc-binary (>=1.13)"]
 # Evaluation:
 ragas = ["pandas (>=2.1.1)", "ragas (>=0.3.3)"]

--- a/src/raglite/_mistral_ocr.py
+++ b/src/raglite/_mistral_ocr.py
@@ -73,7 +73,7 @@ def _get_mistral_client(processor_config: MistralOCRConfig) -> Any:
     try:
         from mistralai import Mistral
     except ImportError as e:
-        error_msg = "To use MistralOCR, please install `mistralai`."
+        error_msg = "To use MistralOCR, please install or upgrade `mistralai`."
         raise ImportError(error_msg) from e
 
     api_key = _get_api_key(processor_config)
@@ -85,7 +85,7 @@ def _get_response_format_converter() -> Any:
     try:
         from mistralai.extra import response_format_from_pydantic_model
     except ImportError as e:
-        error_msg = "To use MistralOCR, please install `mistralai`."
+        error_msg = "To use MistralOCR, please install or upgrade `mistralai`."
         raise ImportError(error_msg) from e
     return response_format_from_pydantic_model
 
@@ -177,7 +177,7 @@ def mistral_ocr_to_markdown(doc_path: Path, *, processor_config: MistralOCRConfi
     Raises
     ------
     ImportError
-        If the mistralai package is not installed.
+        If the mistralai package is not installed or is incompatible.
     ValueError
         If MISTRAL_API_KEY is not set and MistralOCRConfig.api_key is None.
     MistralOCRError

--- a/src/raglite/_mistral_ocr.py
+++ b/src/raglite/_mistral_ocr.py
@@ -73,10 +73,7 @@ def _get_mistral_client(processor_config: MistralOCRConfig) -> Any:
     try:
         from mistralai import Mistral
     except ImportError as e:
-        error_msg = (
-            "To use MistralOCR, please install the `mistral-ocr` extra: "
-            "`pip install raglite[mistral-ocr]` or `uv add raglite[mistral-ocr]`."
-        )
+        error_msg = "To use MistralOCR, please install `mistralai`."
         raise ImportError(error_msg) from e
 
     api_key = _get_api_key(processor_config)
@@ -88,10 +85,7 @@ def _get_response_format_converter() -> Any:
     try:
         from mistralai.extra import response_format_from_pydantic_model
     except ImportError as e:
-        error_msg = (
-            "To use MistralOCR, please install the `mistral-ocr` extra: "
-            "`uv add raglite[mistral-ocr]` or `pip install raglite[mistral-ocr]`."
-        )
+        error_msg = "To use MistralOCR, please install `mistralai`."
         raise ImportError(error_msg) from e
     return response_format_from_pydantic_model
 


### PR DESCRIPTION
This PR fixes multiple CI failures:
- Narrows the declared Python support range from `<4.0` to `<3.14`.
- Removes the `mistral-ocr` extra because `mistralai` is currently unavailable/quarantined on PyPI, causing `uv sync --all-extras` to fail. The Mistral OCR integration still lazy-imports `mistralai`; users who need the feature are instructed to install `mistralai` directly.
- Fixes the lint failure from the pre-commit mypy hook. Pre-commit was passing Python files to mypy in small batches, which triggered mypy internal errors in the highest-resolution CI jobs. The hook now runs one project-level check with `mypy src tests` and disables filename passing, so mypy sees the full source/test graph in one invocation. The tradeoff is that local mypy pre-commit runs now always check `src` and `tests`, though in this repo the single full-project run is still only a few seconds.