### PR TITLE
docs: import Literal in the metadata-expansion example

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ insert_documents(documents, config=my_config)
 You may also want to expand the document metadata before insertion:
 
 ```python
-from typing import Annotated
+from typing import Annotated, Literal
 from pydantic import Field
 from raglite import expand_document_metadata
 


### PR DESCRIPTION
The "expand the document metadata" example in the README uses `Literal[...]` for the `topics` field but only imports `Annotated` from `typing`. Copy-pasting the snippet as-is raises `NameError: name Literal is not defined`.

This one-line fix adds `Literal` to the import so the example runs as written. Docs-only — no logic change.

Reproduction (before fix):
```
>>> from typing import Annotated
>>> Annotated[list[Literal["A"]], ...]
NameError: name Literal is not defined
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README example to include an additional Python import in the metadata expansion snippet, keeping the sample consistent with the documented type usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->