### PR TITLE
fix: star history chart is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,10 +498,10 @@ The following development environments are supported:
 
 ## Star History
 
-<a href="https://star-history.com/#superlinear-ai/raglite&Timeline">
+<a href="https://star-history.dera.page/#superlinear-ai/raglite&type=Timeline">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=superlinear-ai/raglite&type=Timeline&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=superlinear-ai/raglite&type=Timeline" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=superlinear-ai/raglite&type=Timeline" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=superlinear-ai/raglite&type=Timeline&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=superlinear-ai/raglite&type=Timeline" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=superlinear-ai/raglite&type=Timeline" />
  </picture>
 </a>


### PR DESCRIPTION
The star history chart in the README is currently broken due to GitHub stargazer API restrictions. This switches the chart and its wrapping link to star-history.dera.page, a free alternative that requires no API token and keeps the chart working as before.

The original chart was added in commit 35fcded ("docs: add GitHub star history to README (#65)").